### PR TITLE
search-results: support lite and html versions of ddg

### DIFF
--- a/data/filters/search-results.yaml
+++ b/data/filters/search-results.yaml
@@ -7,7 +7,19 @@ params:
   - name: duckduckgo
     description: Generate rules for DuckDuckGo
     type: checkbox
-    default: true
+    default: false
+  - name: duckduckgo-html
+    description: Also support DuckDuckGo's html-only interface
+    link: "https://html.duckduckgo.com/html/"
+    type: checkbox
+    onlyif: duckduckgo
+    default: false
+  - name: duckduckgo-lite
+    description: Also support DuckDuckGo's lite interface
+    link: "https://lite.duckduckgo.com/lite/"
+    type: checkbox
+    onlyif: duckduckgo
+    default: false
   - name: google
     description: Generate rules for Google Search
     type: checkbox
@@ -471,6 +483,15 @@ template: |
   {{#if ../duckduckgo}}
   duckduckgo.com##a[data-testid="result-title-a"][href*="{{site}}"]:upward(.nrn-react-div)
   duckduckgo.com##.tile-wrap a[href*="{{site}}"]:upward(.tile)
+  {{/if}}
+  {{#if ../duckduckgo-html}}
+  html.duckduckgo.com##.results a.result__a[href*="{{site}}"]:upward(.result)
+  {{/if}}
+  {{#if ../duckduckgo-lite}}
+  lite.duckduckgo.com##.result-link[href*="{{site}}"]:upward(tr)
+  lite.duckduckgo.com##.result-link[href*="{{site}}"]:upward(tr) + tr
+  lite.duckduckgo.com##.result-link[href*="{{site}}"]:upward(tr) + tr + tr
+  lite.duckduckgo.com##.result-link[href*="{{site}}"]:upward(tr) + tr + tr + tr
   {{/if}}
   {{#if ../kagi}}
   kagi.com##.search-result:has(a.__sri-url[href*="{{site}}"])

--- a/data/filters/search-results.yaml
+++ b/data/filters/search-results.yaml
@@ -554,6 +554,21 @@ tests:
       kagi.com##._0_image_item[data-host_url*="snapcraft.io/install"]
       searx.thegpm.org###main_results .result:has(a[href*="snapcraft.io/install"])
       search.disroot.org###main_results .result:has(a[href*="snapcraft.io/install"])
+  - params:
+      duckduckgo-html: true
+      sites:
+        - .pinterest.
+    output: |
+      html.duckduckgo.com##.results a.result__a[href*=".pinterest."]:upward(.result)
+  - params:
+      duckduckgo-lite: true
+      sites:
+        - .pinterest.
+    output: |
+      lite.duckduckgo.com##.result-link[href*=".pinterest."]:upward(tr)
+      lite.duckduckgo.com##.result-link[href*=".pinterest."]:upward(tr) + tr
+      lite.duckduckgo.com##.result-link[href*=".pinterest."]:upward(tr) + tr + tr
+      lite.duckduckgo.com##.result-link[href*=".pinterest."]:upward(tr) + tr + tr + tr
   - output: ""
 ---
 

--- a/data/pages/view-filter-param-link.hbs
+++ b/data/pages/view-filter-param-link.hbs
@@ -1,0 +1,5 @@
+{{#with link}}
+    <a class="ps-1 pe-1 text-decoration-none" href="{{this}}" rel="nofollow">
+        <i class="ti ti-external-link"></i>
+    </a>
+{{/with}}

--- a/data/pages/view-filter-param.hbs
+++ b/data/pages/view-filter-param.hbs
@@ -1,34 +1,34 @@
 {{#if (eq type "checkbox")}}
-    <div class="mb-3 form-check form-switch{{#with OnlyIf}} ps-lg-4" data-hide-unless="{{this}}{{/with}}">
+    <div class="mb-3 form-check form-switch{{#with OnlyIf}} ms-lg-4" data-hide-unless="{{this}}{{/with}}">
         <input type="checkbox" role="switch" class="form-check-input" id="{{name}}" name="{{name}}"
                {{#equal true (lookup @root.data.params name)}}checked{{/equal}}>
         <label class="form-check-label" for="{{name}}">
-            {{description}}
+            {{description}}{{>view-filter-param-link this}}
             {{>view-filter-pill-new name}}
         </label>
     </div>
 {{else if (eq type "string")}}
-    <div class="mb-3{{#with OnlyIf}} ps-lg-4" data-hide-unless="{{this}}{{/with}}">
+    <div class="mb-3{{#with OnlyIf}} ms-lg-4" data-hide-unless="{{this}}{{/with}}">
         <label class="form-label" for="{{name}}">
-            {{description}}:
+            {{description}}{{>view-filter-param-link this}}:
             {{>view-filter-pill-new name}}
         </label>
         <input class="form-control" id="{{name}}" name="{{name}}" spellcheck="false"
                value="{{lookup @root.data.params name}}">
     </div>
 {{else if (eq type "multiline")}}
-    <div class="mb-3{{#with OnlyIf}} ps-lg-4" data-hide-unless="{{this}}{{/with}}">
+    <div class="mb-3{{#with OnlyIf}} ms-lg-4" data-hide-unless="{{this}}{{/with}}">
         <label class="form-label" for="{{name}}">
-            {{description}}:
+            {{description}}{{>view-filter-param-link this}}:
             {{>view-filter-pill-new name}}
         </label>
         <textarea class="form-control" id="{{name}}" name="{{name}}" spellcheck="false" rows="10">
             {{~lookup @root.data.params name}}</textarea>
     </div>
 {{else if (eq type "list")}}
-    <fieldset class="row mb-3{{#with OnlyIf}} ps-lg-4" data-hide-unless="{{this}}{{/with}}">
+    <fieldset class="row mb-3{{#with OnlyIf}} ms-lg-4" data-hide-unless="{{this}}{{/with}}">
         <legend class="col-form-label col-sm-auto pt-0">
-            {{description}}:
+            {{description}}{{>view-filter-param-link this}}:
             {{>view-filter-pill-new name}}
         </legend>
         <div class="col-lg-9">

--- a/src/db/migrations/0004_duckduckgo_lite.up.sql
+++ b/src/db/migrations/0004_duckduckgo_lite.up.sql
@@ -1,0 +1,7 @@
+--- Don't mark the search-results filter updated for users who disabled duckduckgo support (see PR 167)
+--- This is achieved by updating the params to add the corresponding fields, set to false.
+--- Users who enabled DDG support will see the filter as updated, and offered the new options.
+
+UPDATE filter_instances
+SET params = filter_instances.params || jsonb_build_object('duckduckgo-lite', false, 'duckduckgo-html', false)
+WHERE filter_name='search-results' AND filter_instances.params -> 'duckduckgo' = 'false';

--- a/src/filters/filter.go
+++ b/src/filters/filter.go
@@ -47,6 +47,7 @@ type FilterParam struct {
 	Type        ParamType   `validate:"required,oneof=checkbox string list multiline"`
 	OnlyIf      string      `validate:"omitempty,valid_only_if" yaml:",omitempty"`
 	Default     interface{} `validate:"valid_default"`
+	Link        string      `validate:"omitempty,url"`
 	Presets     []Preset    `validate:"omitempty,preset_allowed,dive" yaml:",omitempty"`
 }
 


### PR DESCRIPTION
- Add optional support for filtering results on https://html.duckduckgo.com/html/ and https://lite.duckduckgo.com/lite/, as sub-options when DDG is enabled.
- Set DDG support to off by default to avoid showing these to new users.
- Don't notify the updated params for users who disabled DDG (automatically setting to false).

Fixes #156