### PR TITLE
Support external authentication via a reverse proxy

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestServerDryRun(t *testing.T) {
 	assert.Equal(t, server.ErrDryRunFinished, server.NewServer(&server.Options{
-		AuthMethod:   "kratos",
-		DatabaseUrl:  "postgresql:///letsblockit",
-		StatsdTarget: "localhost:8125",
-		DryRun:       true,
-		HotReload:    true,
+		AuthMethod:    "kratos",
+		AuthKratosUrl: "http://localhost:4000/.ory",
+		DatabaseUrl:   "postgresql:///letsblockit",
+		StatsdTarget:  "localhost:8125",
+		DryRun:        true,
+		HotReload:     true,
 	}).Start())
 }

--- a/data/pages/_layout.hbs
+++ b/data/pages/_layout.hbs
@@ -48,7 +48,7 @@
                 <a class="nav-link{{#equal "user" @root.CurrentSection}} active"
                         aria-current="page{{/equal}}" href="{{href "user-account" ""}}">My account</a>
             {{else}}
-                <form method="POST" class="me-2" hx-boost="false" action="{{href "start-flow" "loginOrRegistration"}}">
+                <form method="POST" class="me-2" hx-boost="false" action="{{href "user-action" "loginOrRegistration"}}">
                     {{{csrf @root}}}
                     <button class="btn btn-outline-light {{#equal "user" @root.CurrentSection}} active{{/equal}}"
                             type="submit">Login

--- a/data/pages/help/help-use-list.hbs
+++ b/data/pages/help/help-use-list.hbs
@@ -20,7 +20,7 @@
                  data-bs-parent="#accordionExample">
                 <div class="accordion-body">
                     <ul>
-                        <li><a href="{{abp_subscribe_href list_token}}">Click on this link</a></li>
+                        <li><a href="{{abp_subscribe_href list_url}}">Click on this link</a></li>
                         <li>A new tab will open, click the <code>Subscribe</code> button in the top right corner,
                             then close that tab.
                         </li>
@@ -54,7 +54,7 @@
                             <a onclick="copyListAddress()" class="text-decoration-none" style="cursor: pointer">
                                 <span id="list-button" class="badge rounded-pill bg-secondary ms-1">copy it</span>
                                 <br/>
-                                <code id="list-address">{{list_href list_token}}</code>
+                                <code id="list-address">{{list_url}}</code>
                             </a>
                         </li>
                         <li>Click on <code>Apply changes</code></li>
@@ -74,9 +74,9 @@
                 <div class="accordion-body">
                     <p>While uBlock Origin is the main target for this project, most filters should work with
                         other browser-based adblockers.</p>
-                    <p>To install your filter list, <a href="{{abp_subscribe_href list_token}}">click on this link</a>,
+                    <p>To install your filter list, <a href="{{abp_subscribe_href list_url}}">click on this link</a>,
                         or manually add the following URL to your lists:</p>
-                    <code id="list-address">{{list_href list_token}}</code>
+                    <code id="list-address">{{list_url}}</code>
                 </div>
             </div>
         </div>

--- a/data/pages/help/help-use-list.hbs
+++ b/data/pages/help/help-use-list.hbs
@@ -100,7 +100,7 @@
 {{else}}
     <div class="card shadow-sm me-lg-5 ms-lg-5">
         <form class="card-body text-center p-4"
-              method="POST" action="{{href "start-flow" "loginOrRegistration"}}">
+              method="POST" action="{{href "user-action" "loginOrRegistration"}}">
             {{{csrf @root}}}
             <div class="mb-3">You need an account to create and use a filter list.</div>
             <div>

--- a/data/pages/kratos-form.hbs
+++ b/data/pages/kratos-form.hbs
@@ -27,7 +27,7 @@
                         </li>
                     {{else}}
                         <li class="ms-2 nav-item">
-                            <form method="POST" action="{{href "start-flow" Type}}">
+                            <form method="POST" action="{{href "user-action" Type}}">
                                 {{{csrf @root}}}
                                 {{#with @root.Data.return_to}}
                                     <input type="hidden" name="return_to" value="{{.}}">

--- a/data/pages/landing.hbs
+++ b/data/pages/landing.hbs
@@ -70,7 +70,7 @@
             <p>
                 Your filters will update daily on all your browsers, even on your phone with Firefox Mobile.
             </p>
-            <form method="POST" action="{{href "start-flow" "loginOrRegistration"}}">
+            <form method="POST" action="{{href "user-action" "loginOrRegistration"}}">
                 {{{csrf @root}}}
                 <button class="btn btn-primary" type="submit">Create an account</button>
             </form>

--- a/data/pages/list-filters.hbs
+++ b/data/pages/list-filters.hbs
@@ -47,7 +47,7 @@
             </div>
         {{else}}
             <div role="alert" class="alert alert-secondary has-background-secondary-light">
-                <form method="POST" class="form-inline" action="{{href "start-flow" "loginOrRegistration"}}">
+                <form method="POST" class="form-inline" action="{{href "user-action" "loginOrRegistration"}}">
                     {{{csrf @root}}}
                     <span class="align-middle">This website is a collaborative repository of uBlock content filters
                         you can customize and sync across your browsers.

--- a/data/pages/user-account.hbs
+++ b/data/pages/user-account.hbs
@@ -29,10 +29,10 @@
                 Read more about it in <a href="{{href "help" "privacy"}}">our privacy page</a>.
             </p>
             <button type="submit" class="btn btn-primary me-2"
-                    formaction="{{href "start-flow" "settings"}}">Change email or password
+                    formaction="{{href "user-action" "settings"}}">Change email or password
             </button>
             <button type="submit" class="btn btn-dark"
-                    formaction="{{href "start-flow" "logout"}}">Log out
+                    formaction="{{href "user-action" "logout"}}">Log out
             </button>
         </form>
     </div>
@@ -64,7 +64,7 @@
         <div class="card-header">Account needed</div>
         <div class="card-body">
             <p>You need to create an account or login</p>
-            <form method="POST" action="{{href "start-flow" "loginOrRegistration"}}">
+            <form method="POST" action="{{href "user-action" "loginOrRegistration"}}">
                 {{{csrf @root}}}
                 <button type="submit" class="btn btn-primary">Create an account or login</button>
             </form>

--- a/data/pages/user-account.hbs
+++ b/data/pages/user-account.hbs
@@ -11,7 +11,9 @@
                 from the <a href="{{href "list-filters" ""}}">filter list page</a>.
             </p>
             <ul>
-                <li>To use your filters in you browser, <a href="{{href "help" "use-list"}}">follow these instructions</a>.</li>
+                <li>To use your filters in you browser, <a href="{{href "help" "use-list"}}">follow these
+                    instructions</a>.
+                </li>
                 <li>Alternatively, you can <a href="{{href "export-filterlist" list_token}}">export your list</a>
                     for local use.
                 </li>
@@ -21,20 +23,24 @@
 
     <div class="card mb-3 shadow-sm">
         <div class="card-header">Manage my account</div>
-        <form class="card-body" method="POST">
-            {{{csrf @root}}}
-            <p>
-                Account management is provided by
-                <a target="_blank" href="https://www.ory.sh/docs">the fine folks at Ory</a>.
-                Read more about it in <a href="{{href "help" "privacy"}}">our privacy page</a>.
-            </p>
-            <button type="submit" class="btn btn-primary me-2"
-                    formaction="{{href "user-action" "settings"}}">Change email or password
-            </button>
-            <button type="submit" class="btn btn-dark"
-                    formaction="{{href "user-action" "logout"}}">Log out
-            </button>
-        </form>
+        {{#if (href "user-action" "settings")}}
+            <form class="card-body" method="POST">
+                {{{csrf @root}}}
+                <p>
+                    Account management is provided by
+                    <a target="_blank" href="https://www.ory.sh/docs">the fine folks at Ory</a>.
+                    Read more about it in <a href="{{href "help" "privacy"}}">our privacy page</a>.
+                </p>
+                <button type="submit" class="btn btn-primary me-2"
+                        formaction="{{href "user-action" "settings"}}">Change email or password
+                </button>
+                <button type="submit" class="btn btn-dark"
+                        formaction="{{href "user-action" "logout"}}">Log out
+                </button>
+            </form>
+        {{else}}
+            <div class="card-body">Your user ID is <strong>{{@root.UserID}}</strong>.</div>
+        {{/if}}
     </div>
 
     <div class="card mb-3 shadow-sm">

--- a/data/pages/view-filter-render.hbs
+++ b/data/pages/view-filter-render.hbs
@@ -9,7 +9,7 @@
             Preview
         </div>
     {{else}}
-        <form method="POST" class="card-header" action="{{href "start-flow" "loginOrRegistration"}}">
+        <form method="POST" class="card-header" action="{{href "user-action" "loginOrRegistration"}}">
             {{{csrf @root}}}
             <button type="button" class="btn btn-sm btn-outline-success me-1" onclick="copyFilterOutput(this);">
                 <i id="output-copy-icon" class="ti ti-clipboard me-1"></i>

--- a/data/pages/view-filter.hbs
+++ b/data/pages/view-filter.hbs
@@ -98,8 +98,8 @@
                         <div role="alert" class="alert alert-secondary has-background-secondary-light mt-3 ms-3 me-3">
                             <span class="align-middle">This filter does not have any parameters.</span>
                             <button type="submit" class="btn btn-link p-0"
-                                    formaction="{{href "start-flow" "loginOrRegistration"}}"
-                                    hx-post="{{href "start-flow" "loginOrRegistration"}}">
+                                    formaction="{{href "user-action" "loginOrRegistration"}}"
+                                    hx-post="{{href "user-action" "loginOrRegistration"}}">
                                 {{#if @root.UserHasAccount}}
                                     Login to save this filter to your list.
                                 {{else}}

--- a/src/pages/pages_test.go
+++ b/src/pages/pages_test.go
@@ -1,0 +1,50 @@
+package pages
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func nilHandler(_ echo.Context) error { return nil }
+
+func TestRedirect(t *testing.T) {
+	e := echo.New()
+	e.GET("/filters", nilHandler).Name = "list-filters"
+	e.GET("/filters/tag/:tag", nilHandler).Name = "filters-for-tag"
+	pages := &Pages{}
+
+	for name, asserts := range map[string]func(t *testing.T, c echo.Context, rec *httptest.ResponseRecorder){
+		"html no param": func(t *testing.T, c echo.Context, rec *httptest.ResponseRecorder) {
+			assert.NoError(t, pages.RedirectToPage(c, "list-filters"))
+			assert.Equal(t, 302, rec.Code, rec.Body)
+			assert.Equal(t, "/filters", rec.Header().Get("Location"))
+		},
+		"html params": func(t *testing.T, c echo.Context, rec *httptest.ResponseRecorder) {
+			assert.NoError(t, pages.RedirectToPage(c, "filters-for-tag", "test-tag"))
+			assert.Equal(t, 302, rec.Code, rec.Body)
+			assert.Equal(t, "/filters/tag/test-tag", rec.Header().Get("Location"))
+		},
+		"html 303": func(t *testing.T, c echo.Context, rec *httptest.ResponseRecorder) {
+			assert.NoError(t, pages.Redirect(c, http.StatusSeeOther, "/news"))
+			assert.Equal(t, 303, rec.Code, rec.Body)
+			assert.Equal(t, "/news", rec.Header().Get("Location"))
+		},
+		"htmx no param": func(t *testing.T, c echo.Context, rec *httptest.ResponseRecorder) {
+			c.Request().Header.Set("HX-Request", "true")
+			assert.NoError(t, pages.RedirectToPage(c, "list-filters"))
+			assert.Equal(t, 200, rec.Code, rec.Body)
+			assert.Equal(t, "/filters", rec.Header().Get("HX-Redirect"))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			asserts(t, c, rec)
+		})
+	}
+}

--- a/src/server/deps.go
+++ b/src/server/deps.go
@@ -13,8 +13,12 @@ import (
 
 type PageRenderer interface {
 	RegisterHelpers(helpers map[string]interface{})
+	RegisterContextBuilder(b pages.ContextBuilder)
+	BuildPageContext(c echo.Context, title string) *pages.Context
 	Render(c echo.Context, name string, data *pages.Context) error
 	RenderWithSidebar(c echo.Context, name, sidebar string, data *pages.Context) error
+	RedirectToPage(c echo.Context, name string, params ...interface{}) error
+	Redirect(c echo.Context, code int, target string) error
 }
 
 type FilterRepository interface {

--- a/src/server/filters.go
+++ b/src/server/filters.go
@@ -108,7 +108,7 @@ func (s *Server) viewFilter(c echo.Context) error {
 		}); err != nil {
 			return err
 		}
-		return s.redirectToPage(c, "list-filters")
+		return s.pages.RedirectToPage(c, "list-filters")
 	case hc.UserLoggedIn:
 		// If no params are passed, source from the user's filters
 		f, err := s.store.GetInstanceForUserAndFilter(c.Request().Context(), db.GetInstanceForUserAndFilterParams{

--- a/src/server/filters_test.go
+++ b/src/server/filters_test.go
@@ -335,11 +335,8 @@ func (s *ServerTestSuite) TestViewFilter_Disable() {
 		UserID:     s.user,
 		FilterName: "filter2",
 	}).Return(nil)
-
-	s.runRequest(req, func(t *testing.T, rec *httptest.ResponseRecorder) {
-		assert.Equal(t, 302, rec.Code)
-		assert.Equal(t, "/filters", rec.Header().Get("Location"))
-	})
+	s.expectP.RedirectToPage(gomock.Any(), "list-filters")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestViewFilter_MissingCSRF() {

--- a/src/server/help.go
+++ b/src/server/help.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/url"
 	"sync"
 
 	"github.com/labstack/echo/v4"
@@ -74,7 +75,15 @@ func (s *Server) helpPages(c echo.Context) error {
 		info, err := s.store.GetListForUser(c.Request().Context(), hc.UserID)
 		if err == nil {
 			hc.Add("has_filters", info.InstanceCount > 0)
-			hc.Add("list_token", info.Token.String())
+			listUrl := url.URL{
+				Scheme: c.Scheme(),
+				Host:   c.Request().Host,
+				Path:   c.Echo().Reverse("render-filterlist", info.Token.String()),
+			}
+			if s.options.ListDownloadDomain != "" {
+				listUrl.Host = s.options.ListDownloadDomain
+			}
+			hc.Add("list_url", listUrl.String())
 		}
 	}
 

--- a/src/server/helpers.go
+++ b/src/server/helpers.go
@@ -31,12 +31,9 @@ func buildHelpers(e echoInterface, assetHash string) map[string]interface{} {
 		"href": func(route string, args string) string {
 			return href(e, route, args)
 		},
-		"list_href": func(token string) string {
-			return listDownloadRef(e, token)
-		},
-		"abp_subscribe_href": func(token string) string {
+		"abp_subscribe_href": func(listUrl string) string {
 			return fmt.Sprintf("abp:subscribe?location=%s&title=%s",
-				url.QueryEscape(listDownloadRef(e, token)),
+				url.QueryEscape(listUrl),
 				url.QueryEscape("letsblock.it - My filters"))
 		},
 		"lookup_list": func(obj map[string]interface{}, key string) []string {
@@ -65,10 +62,6 @@ func buildHelpers(e echoInterface, assetHash string) map[string]interface{} {
 			return fmt.Sprintf("%s://%s", c.RequestInfo.Scheme(), c.RequestInfo.Request().Host)
 		},
 	}
-}
-
-func listDownloadRef(e echoInterface, token string) string {
-	return "https://get.letsblock.it" + href(e, "render-filterlist", token)
 }
 
 func href(e echoInterface, route string, args string) string {

--- a/src/server/list.go
+++ b/src/server/list.go
@@ -34,7 +34,7 @@ func (s *Server) renderList(c echo.Context) error {
 			return echo.ErrNotFound
 		} else if e != nil {
 			return e
-		} else if s.isUserBanned(storedList.UserID) {
+		} else if s.bans.IsBanned(storedList.UserID) {
 			return echo.ErrForbidden
 		}
 

--- a/src/server/list.go
+++ b/src/server/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/db"
 	"github.com/letsblockit/letsblockit/src/filters"
+	"github.com/letsblockit/letsblockit/src/users/auth"
 	"gopkg.in/yaml.v2"
 )
 
@@ -71,7 +72,7 @@ func (s *Server) exportList(c echo.Context) error {
 			return echo.ErrNotFound
 		} else if e != nil {
 			return e
-		} else if getUser(c).Id() != storedList.UserID {
+		} else if auth.GetUserId(c) != storedList.UserID {
 			return echo.ErrForbidden
 		}
 		storedInstances, e = q.GetInstancesForList(ctx, storedList.ID)

--- a/src/server/list_test.go
+++ b/src/server/list_test.go
@@ -107,7 +107,7 @@ func (s *ServerTestSuite) TestRenderList_BannedUser() {
 func (s *ServerTestSuite) TestExportList_OK() {
 	token, err := uuid.Parse("59dc36b7-aca5-46a1-a742-cf46dd2cac10")
 	s.NoError(err)
-	req := httptest.NewRequest(http.MethodGet, "/list/"+token.String()+"/export", nil)
+	req := httptest.NewRequest(http.MethodGet, "/export/"+token.String(), nil)
 	req.AddCookie(verifiedCookie)
 
 	s.expectQ.GetListForToken(gomock.Any(), token).Return(db.GetListForTokenRow{
@@ -158,7 +158,7 @@ func (s *ServerTestSuite) TestExportList_BadUser() {
 		}
 		otherUser = uuid.New().String()
 	}
-	req := httptest.NewRequest(http.MethodGet, "/list/"+token.String()+"/export", nil)
+	req := httptest.NewRequest(http.MethodGet, "/export/"+token.String(), nil)
 	req.AddCookie(verifiedCookie)
 
 	s.expectQ.GetListForToken(gomock.Any(), token).Return(db.GetListForTokenRow{

--- a/src/server/mocks/deps.go
+++ b/src/server/mocks/deps.go
@@ -40,6 +40,65 @@ func (m *MockPageRenderer) EXPECT() *MockPageRendererMockRecorder {
 	return m.recorder
 }
 
+// BuildPageContext mocks base method.
+func (m *MockPageRenderer) BuildPageContext(c echo.Context, title string) *pages.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildPageContext", c, title)
+	ret0, _ := ret[0].(*pages.Context)
+	return ret0
+}
+
+// BuildPageContext indicates an expected call of BuildPageContext.
+func (mr *MockPageRendererMockRecorder) BuildPageContext(c, title interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildPageContext", reflect.TypeOf((*MockPageRenderer)(nil).BuildPageContext), c, title)
+}
+
+// Redirect mocks base method.
+func (m *MockPageRenderer) Redirect(c echo.Context, code int, target string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Redirect", c, code, target)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Redirect indicates an expected call of Redirect.
+func (mr *MockPageRendererMockRecorder) Redirect(c, code, target interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Redirect", reflect.TypeOf((*MockPageRenderer)(nil).Redirect), c, code, target)
+}
+
+// RedirectToPage mocks base method.
+func (m *MockPageRenderer) RedirectToPage(c echo.Context, name string, params ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{c, name}
+	for _, a := range params {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RedirectToPage", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RedirectToPage indicates an expected call of RedirectToPage.
+func (mr *MockPageRendererMockRecorder) RedirectToPage(c, name interface{}, params ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{c, name}, params...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedirectToPage", reflect.TypeOf((*MockPageRenderer)(nil).RedirectToPage), varargs...)
+}
+
+// RegisterContextBuilder mocks base method.
+func (m *MockPageRenderer) RegisterContextBuilder(b pages.ContextBuilder) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterContextBuilder", b)
+}
+
+// RegisterContextBuilder indicates an expected call of RegisterContextBuilder.
+func (mr *MockPageRendererMockRecorder) RegisterContextBuilder(b interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContextBuilder", reflect.TypeOf((*MockPageRenderer)(nil).RegisterContextBuilder), b)
+}
+
 // RegisterHelpers mocks base method.
 func (m *MockPageRenderer) RegisterHelpers(helpers map[string]interface{}) {
 	m.ctrl.T.Helper()

--- a/src/server/ory.go
+++ b/src/server/ory.go
@@ -16,15 +16,17 @@ import (
 )
 
 const (
-	userContextKey      = "_user"
-	hasKratosContextKey = "_has_kratos"
-	oryCookieNamePrefix = "ory_session_"
-	oryGetFlowPattern   = "/self-service/%s/flows?id=%s"
-	oryStartFlowPattern = "/self-service/%s/browser"
-	oryReturnToPattern  = "?return_to=%s"
-	oryLogoutInfoPath   = "/self-service/logout/browser"
-	oryWhoamiPath       = "/sessions/whoami"
-	returnToKey         = "return_to"
+	hasAccountCookieName  = "has_account"
+	hasAccountCookieValue = "true"
+	userContextKey        = "_user"
+	hasKratosContextKey   = "_has_kratos"
+	oryCookieNamePrefix   = "ory_session_"
+	oryGetFlowPattern     = "/self-service/%s/flows?id=%s"
+	oryStartFlowPattern   = "/self-service/%s/browser"
+	oryReturnToPattern    = "?return_to=%s"
+	oryLogoutInfoPath     = "/self-service/logout/browser"
+	oryWhoamiPath         = "/sessions/whoami"
+	returnToKey           = "return_to"
 )
 
 var proxyClient = http.Client{
@@ -132,6 +134,17 @@ func (s *Server) buildOryMiddleware() echo.MiddlewareFunc {
 			} else if user.IsActive() {
 				authCache.SetDefault(cookies, &user)
 				c.Set(userContextKey, &user)
+			}
+
+			if _, err := c.Cookie(hasAccountCookieName); err == http.ErrNoCookie {
+				c.SetCookie(&http.Cookie{
+					Name:     hasAccountCookieName,
+					Value:    hasAccountCookieValue,
+					Path:     "/",
+					Expires:  time.Now().AddDate(10, 0, 0),
+					HttpOnly: true,
+					SameSite: http.SameSiteStrictMode,
+				})
 			}
 
 			return next(c)

--- a/src/server/ory.go
+++ b/src/server/ory.go
@@ -127,7 +127,7 @@ func (s *Server) buildOryMiddleware() echo.MiddlewareFunc {
 			var user oryUser
 			if err := s.queryKratos(c, "whoami", endpoint, &user); err != nil {
 				s.echo.Logger.Error("auth error: %w", err)
-			} else if s.isUserBanned(user.Id()) {
+			} else if s.bans.IsBanned(user.Id()) {
 				return echo.ErrForbidden
 			} else if user.IsActive() {
 				authCache.SetDefault(cookies, &user)

--- a/src/server/ory_test.go
+++ b/src/server/ory_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,56 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/pages"
+	"github.com/letsblockit/letsblockit/src/users/auth"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNilOryUser(t *testing.T) {
-	var user *oryUser
-	assert.False(t, user.IsActive())
-	assert.EqualValues(t, "", user.Id())
-}
-
-func TestVerifiedOryUser(t *testing.T) {
-	payload := `{
-	  "id": "d631b403-eb29-4a5b-8829-125da6ebdf75",
-	  "active": true,
-	  "identity": {
-		"id": "9a3f8aeb-729a-44cf-bede-f885175344ef",
-		"verifiable_addresses": [
-		  {
-			"id": "0988fc40-3cb1-4174-b867-cac9de28f1a4",
-			"value": "test@example.com",
-			"verified": true
-		  }
-		]
-	  }
-	}`
-	user := new(oryUser)
-	assert.NoError(t, json.Unmarshal([]byte(payload), user))
-	assert.True(t, user.IsActive())
-	assert.Equal(t, "9a3f8aeb-729a-44cf-bede-f885175344ef", user.Id())
-}
-
-func TestInactiveOrySession(t *testing.T) {
-	payload := `{
-	  "id": "d631b403-eb29-4a5b-8829-125da6ebdf75",
-	  "identity": {
-		"id": "9a3f8aeb-729a-44cf-bede-f885175344ef",
-		"verifiable_addresses": [
-		  {
-			"id": "0988fc40-3cb1-4174-b867-cac9de28f1a4",
-			"value": "test@example.com",
-			"verified": true
-		  }
-		]
-	  }
-	}`
-	user := new(oryUser)
-	assert.NoError(t, json.Unmarshal([]byte(payload), user))
-	assert.False(t, user.IsActive())
-}
+// TODO: rewrite these tests out of the main suite and into the users/auth package
 
 func (s *ServerTestSuite) TestRenderKratosForm_OK() {
 	req := httptest.NewRequest(http.MethodGet, "/user/forms/login?flow=123456", nil)
@@ -69,37 +26,35 @@ func (s *ServerTestSuite) TestRenderKratosForm_OK() {
 			"b": "2",
 		},
 		"return_to": "https://target",
-		"settings":  supportedForms["login"],
+		"settings":  auth.SupportedForms["login"],
 	})
 	s.runRequest(req, assertOk)
 }
 
-func (s *ServerTestSuite) TestRenderKratosForm_KratosDown() {
-	s.kratosServer.Close() // Kratos is unresponsive, continue anonymous
-	req := httptest.NewRequest(http.MethodGet, "/user/forms/login?flow=123456", nil)
-	s.runRequest(req, assertRedirect("/.ory/ui/login?flow=123456"))
-}
-
 func (s *ServerTestSuite) TestRenderKratosForm_ErrFormType() {
 	req := httptest.NewRequest(http.MethodGet, "/user/forms/unknown?flow=123456", nil)
-	s.runRequest(req, assertRedirect("/.ory/ui/unknown?flow=123456"))
+	s.expectP.Redirect(gomock.Any(), 302, s.kratosServer.URL+"/ui/unknown?flow=123456")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestRenderKratosForm_ErrBadFlow() {
 	req := httptest.NewRequest(http.MethodGet, "/user/forms/login?flow=666", nil)
-	s.runRequest(req, assertRedirect("/.ory/ui/login?flow=666"))
+	s.expectP.Redirect(gomock.Any(), 302, s.kratosServer.URL+"/ui/login?flow=666")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Settings() {
 	req := httptest.NewRequest(http.MethodPost, "/user/action/settings", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/settings/browser"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/settings/browser")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Register() {
 	req := httptest.NewRequest(http.MethodPost, "/user/action/loginOrRegistration", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/registration/browser"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/registration/browser")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Login() {
@@ -109,13 +64,15 @@ func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Login() {
 		Name:  "has_account",
 		Value: "true",
 	})
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login() {
 	req := httptest.NewRequest(http.MethodPost, "/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromForm() {
@@ -126,28 +83,32 @@ func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromForm() {
 		strings.NewReader(form.Encode()))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://myserver/ignore")
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser?return_to=https://myserver/page"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser?return_to=https://myserver/page")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromReferer() {
 	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://myserver/page")
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser?return_to=https://myserver/page"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser?return_to=https://myserver/page")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToNotInDomain() {
 	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://anotherserver/page")
-	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser"))
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Logout() {
 	req := httptest.NewRequest(http.MethodPost, "/user/action/logout", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.AddCookie(verifiedCookie)
-	s.runRequest(req, assertSeeOther("targetURL"))
+	s.expectP.Redirect(gomock.Any(), 303, "targetURL")
+	s.runRequest(req, assertOk)
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_MissingCSRF() {

--- a/src/server/ory_test.go
+++ b/src/server/ory_test.go
@@ -91,19 +91,19 @@ func (s *ServerTestSuite) TestRenderKratosForm_ErrBadFlow() {
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Settings() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/settings", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "/user/action/settings", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/settings/browser"))
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Register() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/loginOrRegistration", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "/user/action/loginOrRegistration", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/registration/browser"))
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Login() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/loginOrRegistration", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "/user/action/loginOrRegistration", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.AddCookie(&http.Cookie{
 		Name:  "has_account",
@@ -113,7 +113,7 @@ func (s *ServerTestSuite) TestStartKratosFlow_LoginOrRegistration_Login() {
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/login", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser"))
 }
@@ -122,7 +122,7 @@ func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromForm() {
 	form := make(url.Values)
 	form.Add(csrfLookup, s.csrf)
 	form.Add("return_to", "https://myserver/page")
-	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/start/login",
+	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/action/login",
 		strings.NewReader(form.Encode()))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://myserver/ignore")
@@ -130,28 +130,28 @@ func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromForm() {
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToFromReferer() {
-	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/start/login", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://myserver/page")
 	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser?return_to=https://myserver/page"))
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Login_ReturnToNotInDomain() {
-	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/start/login", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "https://myserver/user/action/login", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.Header.Set("Referer", "https://anotherserver/page")
 	s.runRequest(req, assertSeeOther(s.kratosServer.URL+"/self-service/login/browser"))
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_Logout() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/logout", s.csrfBody())
+	req := httptest.NewRequest(http.MethodPost, "/user/action/logout", s.csrfBody())
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 	req.AddCookie(verifiedCookie)
 	s.runRequest(req, assertSeeOther("targetURL"))
 }
 
 func (s *ServerTestSuite) TestStartKratosFlow_MissingCSRF() {
-	req := httptest.NewRequest(http.MethodPost, "/user/start/logout", nil)
+	req := httptest.NewRequest(http.MethodPost, "/user/action/logout", nil)
 	req.AddCookie(verifiedCookie)
 	s.runRequest(req, func(t *testing.T, recorder *httptest.ResponseRecorder) {
 		assert.Equal(t, 400, recorder.Result().StatusCode)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -36,17 +36,18 @@ const (
 )
 
 type Options struct {
-	Address          string `default:"127.0.0.1:8765" help:"address to listen to"`
-	UseSystemdSocket bool   `help:"use a systemd socket instead of opening a port"`
-	DatabaseUrl      string `default:"postgresql:///letsblockit" help:"psql database to connect to"`
-	LogLevel         string `default:"info" enum:"debug,info,warn,error,off" help:"http log level"`
-	AuthMethod       string `required:"" enum:"kratos" help:"authentication method to use"`
-	AuthKratosUrl    string `default:"http://localhost:4000/.ory" help:"url of the kratos API, defaults to using local ory proxy"`
-	StatsdTarget     string `placeholder:"localhost:8125" help:"address to send statsd metrics to, disabled by default"`
-	CacheDir         string `placeholder:"/tmp" help:"folder to cache external resources in during local development"`
-	OfficialInstance bool   `help:"turn on behaviours specific to the official letsblock.it instances"`
-	HotReload        bool   `help:"reload frontend when the backend restarts"`
-	DryRun           bool   `hidden:""`
+	Address                string `default:"127.0.0.1:8765" help:"address to listen to"`
+	UseSystemdSocket       bool   `help:"use a systemd socket instead of opening a port"`
+	DatabaseUrl            string `default:"postgresql:///letsblockit" help:"psql database to connect to"`
+	LogLevel               string `default:"info" enum:"debug,info,warn,error,off" help:"http log level"`
+	AuthMethod             string `required:"" enum:"kratos" help:"authentication method to use"`
+	AuthExternalHeaderName string `placeholder:"X-Auth-Request-User" help:"name for the cookie set by the external authenticating proxy"`
+	AuthKratosUrl          string `default:"http://localhost:4000/.ory" help:"url of the kratos API, defaults to using local ory proxy"`
+	StatsdTarget           string `placeholder:"localhost:8125" help:"address to send statsd metrics to, disabled by default"`
+	CacheDir               string `placeholder:"/tmp" help:"folder to cache external resources in during local development"`
+	OfficialInstance       bool   `help:"turn on behaviours specific to the official letsblock.it instances"`
+	HotReload              bool   `help:"reload frontend when the backend restarts"`
+	DryRun                 bool   `hidden:""`
 }
 
 var navigationLinks = []struct {
@@ -127,6 +128,11 @@ func (s *Server) Start() error {
 			return fmt.Errorf("missing required parameter auth-kratos-url")
 		}
 		s.auth = auth.NewOryBackend(s.options.AuthKratosUrl, s.pages, s.statsd)
+	case "external":
+		if s.options.AuthExternalHeaderName == "" {
+			return fmt.Errorf("missing required parameter auth-external-header-name")
+		}
+		s.auth = auth.NewExternal(s.options.AuthExternalHeaderName)
 	default:
 		return fmt.Errorf("unsupported auth method %s", s.options.AuthMethod)
 	}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -36,19 +36,19 @@ const (
 )
 
 type Options struct {
-	Address                string `default:"127.0.0.1:8765" help:"address to listen to"`
-	UseSystemdSocket       bool   `help:"use a systemd socket instead of opening a port"`
-	DatabaseUrl            string `default:"postgresql:///letsblockit" help:"psql database to connect to"`
-	LogLevel               string `default:"info" enum:"debug,info,warn,error,off" help:"http log level"`
-	AuthMethod             string `required:"" enum:"kratos" help:"authentication method to use"`
-	AuthExternalHeaderName string `placeholder:"X-Auth-Request-User" help:"name for the cookie set by the external authenticating proxy"`
-	AuthKratosUrl          string `default:"http://localhost:4000/.ory" help:"url of the kratos API, defaults to using local ory proxy"`
-	ListDownloadDomain     string `help:"domain to use for list downloads, leave empty to use the main domain"`
-	StatsdTarget           string `placeholder:"localhost:8125" help:"address to send statsd metrics to, disabled by default"`
-	CacheDir               string `placeholder:"/tmp" help:"folder to cache external resources in during local development"`
-	OfficialInstance       bool   `help:"turn on behaviours specific to the official letsblock.it instances"`
-	HotReload              bool   `help:"reload frontend when the backend restarts"`
-	DryRun                 bool   `hidden:""`
+	Address             string `default:"127.0.0.1:8765" help:"address to listen to"`
+	UseSystemdSocket    bool   `help:"use a systemd socket instead of opening a port"`
+	DatabaseUrl         string `default:"postgresql:///letsblockit" help:"psql database to connect to"`
+	LogLevel            string `default:"info" enum:"debug,info,warn,error,off" help:"http log level"`
+	AuthMethod          string `required:"" enum:"kratos,proxy" help:"authentication method to use"`
+	AuthProxyHeaderName string `placeholder:"X-Auth-Request-User" help:"name for the cookie set by the reverse proxy"`
+	AuthKratosUrl       string `default:"http://localhost:4000/.ory" help:"url of the kratos API, defaults to using local ory proxy"`
+	ListDownloadDomain  string `help:"domain to use for list downloads, leave empty to use the main domain"`
+	StatsdTarget        string `placeholder:"localhost:8125" help:"address to send statsd metrics to, disabled by default"`
+	CacheDir            string `placeholder:"/tmp" help:"folder to cache external resources in during local development"`
+	OfficialInstance    bool   `help:"turn on behaviours specific to the official letsblock.it instances"`
+	HotReload           bool   `help:"reload frontend when the backend restarts"`
+	DryRun              bool   `hidden:""`
 }
 
 var navigationLinks = []struct {
@@ -129,11 +129,11 @@ func (s *Server) Start() error {
 			return fmt.Errorf("missing required parameter auth-kratos-url")
 		}
 		s.auth = auth.NewOryBackend(s.options.AuthKratosUrl, s.pages, s.statsd)
-	case "external":
-		if s.options.AuthExternalHeaderName == "" {
-			return fmt.Errorf("missing required parameter auth-external-header-name")
+	case "proxy":
+		if s.options.AuthProxyHeaderName == "" {
+			return fmt.Errorf("missing required parameter auth-proxy-header-name")
 		}
-		s.auth = auth.NewExternal(s.options.AuthExternalHeaderName)
+		s.auth = auth.NewProxy(s.options.AuthProxyHeaderName)
 	default:
 		return fmt.Errorf("unsupported auth method %s", s.options.AuthMethod)
 	}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -234,7 +234,7 @@ func (s *Server) setupRouter() {
 	withAuth.GET("/filters/:name", s.viewFilter).Name = "view-filter"
 	withAuth.POST("/filters/:name", s.viewFilter)
 
-	withAuth.GET("/list/:token/export", s.exportList).Name = "export-filterlist"
+	withAuth.GET("/export/:token", s.exportList).Name = "export-filterlist"
 	withAuth.GET("/user/account", s.userAccount).Name = "user-account"
 	withAuth.POST("/user/rotate-token", s.rotateListToken).Name = "rotate-list-token"
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/letsblockit/letsblockit/src/news"
 	"github.com/letsblockit/letsblockit/src/pages"
 	"github.com/letsblockit/letsblockit/src/users"
+	"github.com/letsblockit/letsblockit/src/users/auth"
 )
 
 var ErrDryRunFinished = errors.New("dry run finished")
@@ -67,6 +68,7 @@ var navigationLinks = []struct {
 
 type Server struct {
 	assets      *wrappedAssets
+	auth        auth.Backend
 	bans        *users.BanManager
 	echo        *echo.Echo
 	filters     FilterRepository
@@ -119,7 +121,18 @@ func (s *Server) Start() error {
 		s.statsd = &statsd.NoOpClient{}
 	}
 
+	switch s.options.AuthMethod {
+	case "kratos":
+		if s.options.AuthKratosUrl == "" {
+			return fmt.Errorf("missing required parameter auth-kratos-url")
+		}
+		s.auth = auth.NewOryBackend(s.options.AuthKratosUrl, s.pages, s.statsd)
+	default:
+		return fmt.Errorf("unsupported auth method %s", s.options.AuthMethod)
+	}
+
 	s.pages.RegisterHelpers(buildHelpers(s.echo, s.assets.hash))
+	s.pages.RegisterContextBuilder(s.buildPageContext)
 	s.setupRouter()
 	if s.options.DryRun {
 		return ErrDryRunFinished
@@ -179,21 +192,29 @@ func (s *Server) setupRouter() {
 	anon.GET("/news.atom", s.newsAtomHandler).Name = "news-atom"
 
 	anon.GET("/filters/youtube-streams-chat", func(c echo.Context) error {
-		return s.redirectToPage(c, "view-filter", "youtube-cleanup")
+		return s.pages.RedirectToPage(c, "view-filter", "youtube-cleanup")
 	})
 
-	withAuth := s.echo.Group("")
-	if s.options.AuthKratosUrl != "" {
-		withAuth.Use(s.buildOryMiddleware())
-	}
-	withAuth.Use(middleware.CSRFWithConfig(middleware.CSRFConfig{
-		TokenLookup:    "form:" + csrfLookup,
-		ContextKey:     csrfLookup,
-		CookieName:     csrfLookup,
-		CookiePath:     "/",
-		CookieSameSite: http.SameSiteStrictMode,
-		CookieHTTPOnly: true,
-	}))
+	withAuth := s.echo.Group("",
+		s.auth.BuildMiddleware(),
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				if s.bans.IsBanned(auth.GetUserId(c)) {
+					return echo.ErrForbidden
+				}
+				return next(c)
+			}
+		},
+		middleware.CSRFWithConfig(middleware.CSRFConfig{
+			TokenLookup:    "form:" + csrfLookup,
+			ContextKey:     csrfLookup,
+			CookieName:     csrfLookup,
+			CookiePath:     "/",
+			CookieSameSite: http.SameSiteStrictMode,
+			CookieHTTPOnly: true,
+		}),
+	)
+	s.auth.RegisterRoutes(withAuth)
 
 	withAuth.GET("/", s.landingPageHandler).Name = "landing"
 	withAuth.GET("/help", s.helpPages).Name = "help-main"
@@ -208,8 +229,6 @@ func (s *Server) setupRouter() {
 
 	withAuth.GET("/list/:token/export", s.exportList).Name = "export-filterlist"
 	withAuth.GET("/user/account", s.userAccount).Name = "user-account"
-	withAuth.GET("/user/forms/:type", s.renderKratosForm)
-	withAuth.POST("/user/action/:type", s.startKratosFlow).Name = "user-action"
 	withAuth.POST("/user/rotate-token", s.rotateListToken).Name = "rotate-list-token"
 }
 
@@ -241,20 +260,6 @@ func (s *Server) absoluteReverse(c echo.Context, name string, params ...interfac
 	return u.String()
 }
 
-// redirectToPage the user to another page, either via htmx client-side redirect (form submissions)
-// or http 302 redirect (direct access, js disabled)
-func (s *Server) redirectToPage(c echo.Context, name string, params ...interface{}) error {
-	return s.redirect(c, http.StatusFound, s.echo.Reverse(name, params...))
-}
-
-func (s *Server) redirect(c echo.Context, code int, target string) error {
-	if c.Request().Header.Get("HX-Request") == "true" {
-		c.Response().Header().Set("HX-Redirect", target)
-		return c.NoContent(200)
-	}
-	return c.Redirect(code, target)
-}
-
 func (s *Server) buildPageContext(c echo.Context, title string) *pages.Context {
 	var section string
 	switch c.Request().URL.Path {
@@ -279,15 +284,13 @@ func (s *Server) buildPageContext(c echo.Context, title string) *pages.Context {
 		GreyLogo:         s.options.OfficialInstance && c.Request().Host != mainDomain,
 		HotReload:        s.options.HotReload,
 		RequestInfo:      c,
-	}
-	if _, err := c.Cookie(hasAccountCookieName); err == nil {
-		context.UserHasAccount = true
+		UserHasAccount:   auth.HasAccount(c),
 	}
 	if t, ok := c.Get(csrfLookup).(string); ok {
 		context.CSRFToken = t
 	}
-	if u := getUser(c); u != nil {
-		context.UserID = u.Id()
+	if u := auth.GetUserId(c); u != "" {
+		context.UserID = u
 		context.UserLoggedIn = true
 		context.Preferences, _ = s.preferences.Get(c, context.UserID)
 		if context.Preferences != nil {
@@ -333,7 +336,7 @@ func buildDogstatsMiddleware(dsd statsd.ClientInterface) echo.MiddlewareFunc {
 			if err := next(c); err != nil {
 				c.Error(err)
 			}
-			loggedTag := fmt.Sprintf("logged:%t", c.Get(hasKratosContextKey) != nil)
+			loggedTag := fmt.Sprintf("logged:%t", auth.HasAuth(c))
 			duration := time.Since(start)
 			_ = dsd.Distribution("letsblockit.request_duration", float64(duration.Nanoseconds()), []string{loggedTag}, 1)
 			_ = dsd.Incr("letsblockit.request_count", []string{loggedTag, fmt.Sprintf("status:%d", c.Response().Status)}, 1)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -43,6 +43,7 @@ type Options struct {
 	AuthMethod             string `required:"" enum:"kratos" help:"authentication method to use"`
 	AuthExternalHeaderName string `placeholder:"X-Auth-Request-User" help:"name for the cookie set by the external authenticating proxy"`
 	AuthKratosUrl          string `default:"http://localhost:4000/.ory" help:"url of the kratos API, defaults to using local ory proxy"`
+	ListDownloadDomain     string `help:"domain to use for list downloads, leave empty to use the main domain"`
 	StatsdTarget           string `placeholder:"localhost:8125" help:"address to send statsd metrics to, disabled by default"`
 	CacheDir               string `placeholder:"/tmp" help:"folder to cache external resources in during local development"`
 	OfficialInstance       bool   `help:"turn on behaviours specific to the official letsblock.it instances"`

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -67,7 +67,7 @@ var navigationLinks = []struct {
 
 type Server struct {
 	assets      *wrappedAssets
-	banned      map[string]struct{}
+	bans        *users.BanManager
 	echo        *echo.Echo
 	filters     FilterRepository
 	now         func() time.Time
@@ -98,7 +98,7 @@ func (s *Server) Start() error {
 				errs[0] = db.Migrate(s.options.DatabaseUrl)
 			}
 			if errs[0] == nil {
-				errs[0] = s.loadBannedUsers()
+				s.bans, errs[0] = users.LoadUserBans(s.store)
 			}
 			if errs[0] == nil {
 				s.preferences, errs[0] = users.NewPreferenceManager(s.store)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -209,7 +209,7 @@ func (s *Server) setupRouter() {
 	withAuth.GET("/list/:token/export", s.exportList).Name = "export-filterlist"
 	withAuth.GET("/user/account", s.userAccount).Name = "user-account"
 	withAuth.GET("/user/forms/:type", s.renderKratosForm)
-	withAuth.POST("/user/start/:type", s.startKratosFlow).Name = "start-flow"
+	withAuth.POST("/user/action/:type", s.startKratosFlow).Name = "user-action"
 	withAuth.POST("/user/rotate-token", s.rotateListToken).Name = "rotate-list-token"
 }
 

--- a/src/server/suite_test.go
+++ b/src/server/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsblockit/letsblockit/src/news"
 	"github.com/letsblockit/letsblockit/src/pages"
 	"github.com/letsblockit/letsblockit/src/server/mocks"
+	"github.com/letsblockit/letsblockit/src/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -165,10 +166,8 @@ func (s *ServerTestSuite) SetupTest() {
 }
 
 func (s *ServerTestSuite) setUserBanned() {
-	if s.server.banned == nil {
-		s.server.banned = make(map[string]struct{})
-	}
-	s.server.banned[s.user] = struct{}{}
+	s.expectQ.GetBannedUsers(gomock.Any()).Return([]string{s.user}, nil)
+	s.server.bans, _ = users.LoadUserBans(s.server.store)
 }
 
 func (s *ServerTestSuite) expectRender(page string, data pages.ContextData) *gomock.Call {

--- a/src/server/user.go
+++ b/src/server/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/db"
+	"github.com/letsblockit/letsblockit/src/users/auth"
 )
 
 func (s *Server) userAccount(c echo.Context) error {
@@ -50,17 +51,17 @@ func (s *Server) rotateListToken(c echo.Context) error {
 		confirmation := formParams.Get("confirm")
 		tokenString := formParams.Get("token")
 		token, err := uuid.Parse(tokenString)
-		u := getUser(c)
-		if !u.IsActive() || err != nil || confirmation != "on" {
+		user := auth.GetUserId(c)
+		if user == "" || err != nil || confirmation != "on" {
 			return errors.New("invalid arguments")
 		}
 		return q.RotateListToken(ctx, db.RotateListTokenParams{
-			UserID: u.Id(),
+			UserID: user,
 			Token:  token,
 		})
 	}); err != nil {
 		return err
 	}
 
-	return s.redirect(c, http.StatusSeeOther, s.echo.Reverse("user-account"))
+	return s.pages.Redirect(c, http.StatusSeeOther, s.echo.Reverse("user-account"))
 }

--- a/src/server/user.go
+++ b/src/server/user.go
@@ -4,16 +4,10 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/db"
-)
-
-var (
-	hasAccountCookieName  = "has_account"
-	hasAccountCookieValue = "true"
 )
 
 func (s *Server) userAccount(c echo.Context) error {
@@ -41,15 +35,6 @@ func (s *Server) userAccount(c echo.Context) error {
 			return err
 		}
 	}
-
-	c.SetCookie(&http.Cookie{
-		Name:     hasAccountCookieName,
-		Value:    hasAccountCookieValue,
-		Path:     "/",
-		Expires:  time.Now().AddDate(10, 0, 0),
-		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
-	})
 	return s.pages.Render(c, "user-account", hc)
 }
 

--- a/src/server/user.go
+++ b/src/server/user.go
@@ -16,23 +16,6 @@ var (
 	hasAccountCookieValue = "true"
 )
 
-func (s *Server) loadBannedUsers() error {
-	users, err := s.store.GetBannedUsers(context.Background())
-	if err != nil {
-		return err
-	}
-	s.banned = make(map[string]struct{}, len(users))
-	for _, u := range users {
-		s.banned[u] = struct{}{}
-	}
-	return nil
-}
-
-func (s *Server) isUserBanned(id string) bool {
-	_, found := s.banned[id]
-	return found
-}
-
 func (s *Server) userAccount(c echo.Context) error {
 	hc := s.buildPageContext(c, "My account")
 	hc.NoBoost = true

--- a/src/server/user_test.go
+++ b/src/server/user_test.go
@@ -12,24 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *ServerTestSuite) TestLoadBannedUsers() {
-	assert.Nil(s.T(), s.server.banned)
-	id1, id2, id3 := uuid.New().String(), uuid.New().String(), uuid.New().String()
-	for {
-		if id1 != id2 && id1 != id3 && id2 != id3 {
-			break
-		}
-		id2, id3 = uuid.New().String(), uuid.New().String()
-	}
-	s.expectQ.GetBannedUsers(gomock.Any()).Return([]string{id1, id2, id1}, nil)
-	assert.NoError(s.T(), s.server.loadBannedUsers())
-
-	assert.Len(s.T(), s.server.banned, 2)
-	assert.True(s.T(), s.server.isUserBanned(id1))
-	assert.True(s.T(), s.server.isUserBanned(id2))
-	assert.False(s.T(), s.server.isUserBanned(id3))
-}
-
 func (s *ServerTestSuite) TestUserAccount_Verified() {
 	token := uuid.New()
 	req := httptest.NewRequest(http.MethodGet, "/user/account", nil)

--- a/src/server/user_test.go
+++ b/src/server/user_test.go
@@ -29,7 +29,7 @@ func (s *ServerTestSuite) TestUserAccount_Verified() {
 	s.runRequest(req, func(t *testing.T, rec *httptest.ResponseRecorder) {
 		assert.Equal(t, 200, rec.Code, rec.Body)
 		assert.Len(t, rec.Result().Cookies(), 2)
-		cookie := rec.Result().Cookies()[1]
+		cookie := rec.Result().Cookies()[0]
 		assert.Equal(t, "has_account", cookie.Name)
 		assert.Equal(t, "true", cookie.Value)
 		assert.Equal(t, "/", cookie.Path)

--- a/src/users/auth/auth.go
+++ b/src/users/auth/auth.go
@@ -10,18 +10,18 @@ const (
 	userActionRouteName   = "user-action"
 )
 
-type User interface {
-	Id() string
-}
-
 type Backend interface {
 	BuildMiddleware() echo.MiddlewareFunc
 	RegisterRoutes(group *echo.Group)
 }
 
+func setUserId(c echo.Context, id string) {
+	c.Set(userContextKey, id)
+}
+
 func GetUserId(c echo.Context) string {
-	if u, ok := c.Get(userContextKey).(User); ok {
-		return u.Id()
+	if u, ok := c.Get(userContextKey).(string); ok {
+		return u
 	}
 	return ""
 }

--- a/src/users/auth/auth.go
+++ b/src/users/auth/auth.go
@@ -1,0 +1,36 @@
+package auth
+
+import "github.com/labstack/echo/v4"
+
+const (
+	hasAccountCookieName  = "has_account"
+	hasAccountCookieValue = "true"
+	userContextKey        = "_user"
+	hasAuthContextKey     = "_has_auth"
+	userActionRouteName   = "user-action"
+)
+
+type User interface {
+	Id() string
+}
+
+type Backend interface {
+	BuildMiddleware() echo.MiddlewareFunc
+	RegisterRoutes(group *echo.Group)
+}
+
+func GetUserId(c echo.Context) string {
+	if u, ok := c.Get(userContextKey).(User); ok {
+		return u.Id()
+	}
+	return ""
+}
+
+func HasAccount(c echo.Context) bool {
+	_, err := c.Cookie(hasAccountCookieName)
+	return err == nil
+}
+
+func HasAuth(c echo.Context) bool {
+	return c.Get(hasAuthContextKey) != nil
+}

--- a/src/users/auth/external.go
+++ b/src/users/auth/external.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// External is used to run the server being an authenticating proxy.
+// It expects an HTTP header to be set by the proxy, and uses its value as the unique user ID.
+type External struct {
+	headerName string
+}
+
+func NewExternal(headerName string) *External {
+	return &External{headerName: headerName}
+}
+
+func (e *External) BuildMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if id := c.Request().Header.Get(e.headerName); id != "" {
+				setUserId(c, id)
+				return next(c)
+			}
+			return c.String(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		}
+	}
+}
+
+func (e *External) RegisterRoutes(_ *echo.Group) {}

--- a/src/users/auth/external_test.go
+++ b/src/users/auth/external_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExternalAuthSuite struct {
+	suite.Suite
+	echo       *echo.Echo
+	user       string
+	headerName string
+}
+
+func (s *ExternalAuthSuite) SetupTest() {
+	s.user = random.String(32)
+	s.headerName = random.String(16)
+	s.echo = echo.New()
+	s.echo.Use(NewExternal(s.headerName).BuildMiddleware())
+	s.echo.GET("/", func(c echo.Context) error {
+		return c.String(200, "Hello "+GetUserId(c))
+	})
+}
+
+func (s *ExternalAuthSuite) Test_OK() {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(s.headerName, s.user)
+	rec := httptest.NewRecorder()
+	s.echo.ServeHTTP(rec, req)
+	assert.Equal(s.T(), http.StatusOK, rec.Code, rec.Body)
+	assert.Equal(s.T(), "Hello "+s.user, rec.Body.String())
+}
+
+func (s *ExternalAuthSuite) Test_Unauthorized() {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(s.user, s.user)
+	rec := httptest.NewRecorder()
+	s.echo.ServeHTTP(rec, req)
+	assert.Equal(s.T(), http.StatusUnauthorized, rec.Code, rec.Body)
+}
+
+func TestExternalAuthSuite(t *testing.T) {
+	suite.Run(t, new(ExternalAuthSuite))
+}

--- a/src/users/auth/ory.go
+++ b/src/users/auth/ory.go
@@ -1,4 +1,4 @@
-package server
+package auth
 
 import (
 	"encoding/json"
@@ -9,28 +9,29 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/pages"
 	"zgo.at/zcache"
 )
 
 const (
-	hasAccountCookieName  = "has_account"
-	hasAccountCookieValue = "true"
-	userContextKey        = "_user"
-	hasKratosContextKey   = "_has_kratos"
-	oryCookieNamePrefix   = "ory_session_"
-	oryGetFlowPattern     = "/self-service/%s/flows?id=%s"
-	oryStartFlowPattern   = "/self-service/%s/browser"
-	oryReturnToPattern    = "?return_to=%s"
-	oryLogoutInfoPath     = "/self-service/logout/browser"
-	oryWhoamiPath         = "/sessions/whoami"
-	returnToKey           = "return_to"
+	oryCookieNamePrefix = "ory_session_"
+	oryGetFlowPattern   = "/self-service/%s/flows?id=%s"
+	oryStartFlowPattern = "/self-service/%s/browser"
+	oryReturnToPattern  = "?return_to=%s"
+	oryLogoutInfoPath   = "/self-service/logout/browser"
+	oryWhoamiPath       = "/sessions/whoami"
+	returnToKey         = "return_to"
 )
 
-var proxyClient = http.Client{
-	Timeout: 30 * time.Second,
+// renderer is currently fulfilled by server.Server, we need to decouple this
+type renderer interface {
+	BuildPageContext(c echo.Context, title string) *pages.Context
+	Redirect(c echo.Context, code int, target string) error
+	Render(c echo.Context, name string, data *pages.Context) error
 }
 
 type formTab struct {
@@ -50,7 +51,7 @@ var (
 		Type:  "recovery",
 	}}
 
-	supportedForms = map[string]struct {
+	SupportedForms = map[string]struct {
 		Title string
 		Tabs  []formTab
 		Intro string
@@ -108,11 +109,36 @@ func (u *oryUser) IsActive() bool {
 	return u.Active && u.Identity.Id != uuid.Nil
 }
 
-// buildOryMiddleware tries to resolve an Ory Cloud session from the cookies.
+type OryBackend struct {
+	client   *retryablehttp.Client
+	rootUrl  string
+	renderer renderer
+	statsd   statsd.ClientInterface
+}
+
+func NewOryBackend(rootUrl string, renderer renderer, statsd statsd.ClientInterface) *OryBackend {
+	client := retryablehttp.NewClient()
+	client.RetryWaitMin = 100 * time.Millisecond
+	client.RetryWaitMax = time.Second
+	client.HTTPClient.Timeout = 10 * time.Second
+	return &OryBackend{
+		client:   client,
+		rootUrl:  rootUrl,
+		renderer: renderer,
+		statsd:   statsd,
+	}
+}
+
+func (o *OryBackend) RegisterRoutes(group *echo.Group) {
+	group.GET("/user/forms/:type", o.renderKratosForm)
+	group.POST("/user/action/:type", o.startKratosFlow).Name = userActionRouteName
+}
+
+// BuildMiddleware tries to resolve an Ory Cloud session from the cookies.
 // If it succeeds, a "user" value is added to the context for use by handlers.
-func (s *Server) buildOryMiddleware() echo.MiddlewareFunc {
+func (o *OryBackend) BuildMiddleware() echo.MiddlewareFunc {
 	authCache := zcache.New(15*time.Minute, 10*time.Minute)
-	endpoint := s.options.AuthKratosUrl + oryWhoamiPath
+	endpoint := o.rootUrl + oryWhoamiPath
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -127,10 +153,8 @@ func (s *Server) buildOryMiddleware() echo.MiddlewareFunc {
 			}
 
 			var user oryUser
-			if err := s.queryKratos(c, "whoami", endpoint, &user); err != nil {
-				s.echo.Logger.Error("auth error: %w", err)
-			} else if s.bans.IsBanned(user.Id()) {
-				return echo.ErrForbidden
+			if err := o.queryKratos(c, "whoami", endpoint, &user); err != nil {
+				c.Logger().Error("auth error: %w", err)
 			} else if user.IsActive() {
 				authCache.SetDefault(cookies, &user)
 				c.Set(userContextKey, &user)
@@ -153,9 +177,9 @@ func (s *Server) buildOryMiddleware() echo.MiddlewareFunc {
 }
 
 // getLogoutUrl retrieves the logout url for the current session by calling the proxy
-func (s *Server) getLogoutUrl(c echo.Context) (string, error) {
+func (o *OryBackend) getLogoutUrl(c echo.Context) (string, error) {
 	var info oryLogoutInfo
-	if err := s.queryKratos(c, "logout", s.options.AuthKratosUrl+oryLogoutInfoPath, &info); err != nil {
+	if err := o.queryKratos(c, "logout", o.rootUrl+oryLogoutInfoPath, &info); err != nil {
 		return "", err
 	}
 	if info.URL == "" {
@@ -166,21 +190,21 @@ func (s *Server) getLogoutUrl(c echo.Context) (string, error) {
 
 // renderKratosForm retrieves the flow definition from the proxy and renders the form.
 // If any error occurs, the user is redirected to the Cloud Managed UI as a fallback.
-func (s *Server) renderKratosForm(c echo.Context) error {
+func (o *OryBackend) renderKratosForm(c echo.Context) error {
 	formType := c.Param("type")
 	flowID := c.QueryParams().Get("flow")
 	if formType == "" || flowID == "" {
 		return fmt.Errorf("missing args, got type '%s', flow '%s'", formType, flowID)
 	}
 	hc, err := func() (*pages.Context, error) {
-		formSettings, ok := supportedForms[formType]
+		formSettings, ok := SupportedForms[formType]
 		if !ok {
 			return nil, fmt.Errorf("unsupported form type %s", formType)
 		}
 
 		body := make(map[string]interface{})
-		endpoint := s.options.AuthKratosUrl + fmt.Sprintf(oryGetFlowPattern, formType, flowID)
-		if err := s.queryKratos(c, "flow", endpoint, &body); err != nil {
+		endpoint := o.rootUrl + fmt.Sprintf(oryGetFlowPattern, formType, flowID)
+		if err := o.queryKratos(c, "flow", endpoint, &body); err != nil {
 			return nil, err
 		}
 		ui, ok := body["ui"]
@@ -188,7 +212,7 @@ func (s *Server) renderKratosForm(c echo.Context) error {
 			return nil, errors.New("no UI field in payload")
 		}
 
-		hc := s.buildPageContext(c, formSettings.Title)
+		hc := o.renderer.BuildPageContext(c, formSettings.Title)
 		hc.NoBoost = true
 		hc.Add("type", formType)
 		hc.Add("ui", ui)
@@ -200,24 +224,24 @@ func (s *Server) renderKratosForm(c echo.Context) error {
 	}()
 	if err != nil {
 		c.Logger().Warnf("falling-back to managed UI: %s", err.Error())
-		return c.Redirect(http.StatusFound, fmt.Sprintf("/.ory/ui/%s?flow=%s", formType, flowID))
+		return o.renderer.Redirect(c, http.StatusFound, fmt.Sprintf("%s/ui/%s?flow=%s", o.rootUrl, formType, flowID))
 	}
-	return s.pages.Render(c, "kratos-form", hc)
+	return o.renderer.Render(c, "kratos-form", hc)
 }
 
 // startKratosFlow redirects the requested user to the Kratos flow. It is used via POST instead
 // of direct GET links to avoid search engines and preloading logics starting Kratos flows.
-func (s *Server) startKratosFlow(c echo.Context) error {
+func (o *OryBackend) startKratosFlow(c echo.Context) error {
 	target := c.Param("type")
 	var allowReturnTo bool
 
 	switch target {
 	case "logout":
-		target, err := s.getLogoutUrl(c)
+		target, err := o.getLogoutUrl(c)
 		if err != nil {
 			return nil
 		}
-		return s.redirect(c, http.StatusSeeOther, target)
+		return o.renderer.Redirect(c, http.StatusSeeOther, target)
 	case "loginOrRegistration":
 		allowReturnTo = true
 		if _, err := c.Cookie(hasAccountCookieName); err == nil {
@@ -229,27 +253,27 @@ func (s *Server) startKratosFlow(c echo.Context) error {
 		allowReturnTo = true
 	}
 
-	redirect := s.options.AuthKratosUrl + fmt.Sprintf(oryStartFlowPattern, target)
+	redirect := o.rootUrl + fmt.Sprintf(oryStartFlowPattern, target)
 	if allowReturnTo {
 		if returnTo, inDomain := computeReturnTo(c); inDomain {
 			redirect += fmt.Sprintf(oryReturnToPattern, returnTo)
 		}
 	}
-	return s.redirect(c, http.StatusSeeOther, redirect)
+	return o.renderer.Redirect(c, http.StatusSeeOther, redirect)
 }
 
-func (s *Server) queryKratos(c echo.Context, typeTag, endpoint string, body interface{}) error {
+func (o *OryBackend) queryKratos(c echo.Context, typeTag, endpoint string, body interface{}) error {
 	start := time.Now()
-	c.Set(hasKratosContextKey, true)
+	c.Set(hasAuthContextKey, true)
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := retryablehttp.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate request: %w", err)
 	}
 	req.Header.Set(echo.HeaderCookie, c.Request().Header.Get(echo.HeaderCookie))
 	req.Header.Set("Accept", "application/json")
-	res, err := proxyClient.Do(req)
-	_ = s.statsd.Distribution("letsblockit.ory_request_duration", float64(time.Since(start).Nanoseconds()),
+	res, err := o.client.Do(req)
+	_ = o.statsd.Distribution("letsblockit.ory_request_duration", float64(time.Since(start).Nanoseconds()),
 		[]string{"type:" + typeTag, fmt.Sprintf("ok:%t", err == nil && res.StatusCode == http.StatusOK)}, 1)
 
 	if err != nil {
@@ -259,13 +283,6 @@ func (s *Server) queryKratos(c echo.Context, typeTag, endpoint string, body inte
 
 	if err := json.NewDecoder(res.Body).Decode(body); err != nil {
 		return fmt.Errorf("failed to decode response: %w", err)
-	}
-	return nil
-}
-
-func getUser(c echo.Context) *oryUser {
-	if u, ok := c.Get(userContextKey).(*oryUser); ok {
-		return u
 	}
 	return nil
 }

--- a/src/users/auth/ory_test.go
+++ b/src/users/auth/ory_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNilOryUser(t *testing.T) {
+	var user *oryUser
+	assert.False(t, user.IsActive())
+	assert.EqualValues(t, "", user.Id())
+}
+
+func TestVerifiedOryUser(t *testing.T) {
+	payload := `{
+	  "id": "d631b403-eb29-4a5b-8829-125da6ebdf75",
+	  "active": true,
+	  "identity": {
+		"id": "9a3f8aeb-729a-44cf-bede-f885175344ef",
+		"verifiable_addresses": [
+		  {
+			"id": "0988fc40-3cb1-4174-b867-cac9de28f1a4",
+			"value": "test@example.com",
+			"verified": true
+		  }
+		]
+	  }
+	}`
+	user := new(oryUser)
+	assert.NoError(t, json.Unmarshal([]byte(payload), user))
+	assert.True(t, user.IsActive())
+	assert.Equal(t, "9a3f8aeb-729a-44cf-bede-f885175344ef", user.Id())
+}
+
+func TestInactiveOrySession(t *testing.T) {
+	payload := `{
+	  "id": "d631b403-eb29-4a5b-8829-125da6ebdf75",
+	  "identity": {
+		"id": "9a3f8aeb-729a-44cf-bede-f885175344ef",
+		"verifiable_addresses": [
+		  {
+			"id": "0988fc40-3cb1-4174-b867-cac9de28f1a4",
+			"value": "test@example.com",
+			"verified": true
+		  }
+		]
+	  }
+	}`
+	user := new(oryUser)
+	assert.NoError(t, json.Unmarshal([]byte(payload), user))
+	assert.False(t, user.IsActive())
+}

--- a/src/users/auth/proxy.go
+++ b/src/users/auth/proxy.go
@@ -6,17 +6,17 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// External is used to run the server being an authenticating proxy.
+// Proxy is used to run the server being an authenticating proxy.
 // It expects an HTTP header to be set by the proxy, and uses its value as the unique user ID.
-type External struct {
+type Proxy struct {
 	headerName string
 }
 
-func NewExternal(headerName string) *External {
-	return &External{headerName: headerName}
+func NewProxy(headerName string) *Proxy {
+	return &Proxy{headerName: headerName}
 }
 
-func (e *External) BuildMiddleware() echo.MiddlewareFunc {
+func (e *Proxy) BuildMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if id := c.Request().Header.Get(e.headerName); id != "" {
@@ -28,4 +28,4 @@ func (e *External) BuildMiddleware() echo.MiddlewareFunc {
 	}
 }
 
-func (e *External) RegisterRoutes(_ *echo.Group) {}
+func (e *Proxy) RegisterRoutes(_ *echo.Group) {}

--- a/src/users/auth/proxy_test.go
+++ b/src/users/auth/proxy_test.go
@@ -11,24 +11,24 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ExternalAuthSuite struct {
+type ProxyAuthSuite struct {
 	suite.Suite
 	echo       *echo.Echo
 	user       string
 	headerName string
 }
 
-func (s *ExternalAuthSuite) SetupTest() {
+func (s *ProxyAuthSuite) SetupTest() {
 	s.user = random.String(32)
 	s.headerName = random.String(16)
 	s.echo = echo.New()
-	s.echo.Use(NewExternal(s.headerName).BuildMiddleware())
+	s.echo.Use(NewProxy(s.headerName).BuildMiddleware())
 	s.echo.GET("/", func(c echo.Context) error {
 		return c.String(200, "Hello "+GetUserId(c))
 	})
 }
 
-func (s *ExternalAuthSuite) Test_OK() {
+func (s *ProxyAuthSuite) Test_OK() {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(s.headerName, s.user)
 	rec := httptest.NewRecorder()
@@ -37,7 +37,7 @@ func (s *ExternalAuthSuite) Test_OK() {
 	assert.Equal(s.T(), "Hello "+s.user, rec.Body.String())
 }
 
-func (s *ExternalAuthSuite) Test_Unauthorized() {
+func (s *ProxyAuthSuite) Test_Unauthorized() {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(s.user, s.user)
 	rec := httptest.NewRecorder()
@@ -45,6 +45,6 @@ func (s *ExternalAuthSuite) Test_Unauthorized() {
 	assert.Equal(s.T(), http.StatusUnauthorized, rec.Code, rec.Body)
 }
 
-func TestExternalAuthSuite(t *testing.T) {
-	suite.Run(t, new(ExternalAuthSuite))
+func TestProxyAuthSuite(t *testing.T) {
+	suite.Run(t, new(ProxyAuthSuite))
 }

--- a/src/users/bans.go
+++ b/src/users/bans.go
@@ -1,0 +1,31 @@
+package users
+
+import "context"
+
+type banQuerier interface {
+	GetBannedUsers(ctx context.Context) ([]string, error)
+}
+
+type BanManager struct {
+	bans map[string]struct{}
+}
+
+func LoadUserBans(store banQuerier) (*BanManager, error) {
+	users, err := store.GetBannedUsers(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	bans := make(map[string]struct{}, len(users))
+	for _, u := range users {
+		bans[u] = struct{}{}
+	}
+	return &BanManager{bans: bans}, nil
+}
+
+func (m *BanManager) IsBanned(id string) bool {
+	if m == nil {
+		return false // For unit tests
+	}
+	_, found := m.bans[id]
+	return found
+}

--- a/src/users/bans_test.go
+++ b/src/users/bans_test.go
@@ -1,0 +1,25 @@
+package users
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedBanStore struct {
+	bans []string
+}
+
+func (s *mockedBanStore) GetBannedUsers(_ context.Context) ([]string, error) {
+	return s.bans, nil
+}
+
+func TestLoadBannedUsers(t *testing.T) {
+	bans, err := LoadUserBans(&mockedBanStore{[]string{"one", "two", "one", "four"}})
+	assert.NoError(t, err)
+
+	assert.True(t, bans.IsBanned("one"))
+	assert.True(t, bans.IsBanned("two"))
+	assert.False(t, bans.IsBanned("three"))
+}


### PR DESCRIPTION
Pretty big PR to decouple the codebase from Ory Kratos:

- Move the Ory auth logic to `pkg/users/auth`, create an `auth.Backend` interface and the new `auth.External` backend
- Add the relevant cmdline options
- Refactor some more logic out of Server
- Hide the settings and logout buttons when using external auth

Fixes https://github.com/letsblockit/letsblockit/issues/169

## TODO

- [another PR] make the `pkg/server` tests use a basic dummy auth backend, and move Ory tests to the `pkg/users/auth` package