### PR TITLE
display the full changelog on self-hosted instances

### DIFF
--- a/data/pages/_layout.hbs
+++ b/data/pages/_layout.hbs
@@ -24,8 +24,8 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-primary" aria-label="Main navigation">
     <div class="container-lg">
         <a class="navbar-brand" href="/">
-            <img src="/assets/images/logo.svg{{assetHash}}"
-                 {{#unless MainDomain}}style="filter: grayscale(100%);"{{/unless}}>
+            <img src="/assets/images/logo.svg{{assetHash}}" {{#if GreyLogo}}
+                 style="filter: grayscale(100%);"{{/if}}>
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/data/pages/news.hbs
+++ b/data/pages/news.hbs
@@ -1,6 +1,13 @@
-<h4 class="text-end mb-4">
-    <a href="{{href "news-atom" ""}}" title="ATOM feed for release notes"><i class="ti ti-rss"></i></a>
-</h4>
+<div class="container mb-4 ms-lg-5 me-lg-5 text-center alert">
+    Here are the new filter updates and user-facing features the project has released.
+    You can also subscribe to <a href="{{href "news-atom" ""}}">the RSS feed</a> to stay in the loop.
+
+    {{#if @root.OfficialInstance}}<br/>
+        Self-hosting users can find the full list of changes in
+        <a href="https://github.com/letsblockit/letsblockit/releases">the Github release list</a>.
+    {{/if}}
+</div>
+
 
 <div class="container release-list">
     {{#each releases}}

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -8,6 +8,7 @@ ory proxy --port 4000 http://localhost:8765/ --no-jwt &
 export LETSBLOCKIT_AUTH_METHOD=kratos
 export LETSBLOCKIT_AUTH_KRATOS_URL="http://localhost:4000/.ory"
 export LETSBLOCKIT_CACHE_DIR="/tmp/lbi-cache"
+export LETSBLOCKIT_OFFICIAL_INSTANCE=true
 
 mkdir -p $LETSBLOCKIT_CACHE_DIR
 reflex -r "(cmd|src|data)/" -s -- go run -race ./cmd/server --hot-reload

--- a/src/news/markdown.go
+++ b/src/news/markdown.go
@@ -14,14 +14,17 @@ var (
 )
 
 type releaseNoteRenderer struct {
+	officialInstance bool
 	*blackfriday.HTMLRenderer
 }
 
 func (r *releaseNoteRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
 	switch node.Type {
 	case blackfriday.HorizontalRule:
-		// Stop parsing on the first hr, items below are not relevant for end users
-		return blackfriday.Terminate
+		if r.officialInstance {
+			// Stop parsing on the first hr, items below are not relevant on the official instance
+			return blackfriday.Terminate
+		}
 	case blackfriday.Link:
 		// Match github pull/commit links and shorten the anchor text
 		if bytes.HasPrefix(node.LinkData.Destination, githubLinkPrefix) && node.FirstChild != nil {
@@ -47,6 +50,10 @@ func (r *releaseNoteRenderer) RenderNode(w io.Writer, node *blackfriday.Node, en
 					} else {
 						node.FirstChild.Literal = append([]byte(repoName+"@"), []byte(linkedId[0:7])...)
 					}
+				case "compare":
+					if sameRepo {
+						node.FirstChild.Literal = []byte(linkedId)
+					}
 				}
 			}
 		}
@@ -54,9 +61,10 @@ func (r *releaseNoteRenderer) RenderNode(w io.Writer, node *blackfriday.Node, en
 	return r.HTMLRenderer.RenderNode(w, node, entering)
 }
 
-func initRenderer() blackfriday.Option {
+func initRenderer(officialInstance bool) blackfriday.Option {
 	return blackfriday.WithRenderer(
 		&releaseNoteRenderer{
+			officialInstance: officialInstance,
 			HTMLRenderer: blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{
 				HeadingLevelOffset: 2,
 			}),

--- a/src/news/releases.go
+++ b/src/news/releases.go
@@ -54,16 +54,18 @@ func (r Release) Date() string {
 // The parsed results are cached in memory until the next restart.
 type ReleaseClient struct {
 	sync.Mutex
-	url      string
-	cacheDir string
-	latestAt time.Time
-	releases []*Release
+	url              string
+	cacheDir         string
+	officialInstance bool
+	latestAt         time.Time
+	releases         []*Release
 }
 
-func NewReleaseClient(url string, cacheDir string) *ReleaseClient {
+func NewReleaseClient(url string, cacheDir string, officialInstance bool) *ReleaseClient {
 	return &ReleaseClient{
-		url:      url,
-		cacheDir: cacheDir,
+		url:              url,
+		cacheDir:         cacheDir,
+		officialInstance: officialInstance,
 	}
 }
 
@@ -105,7 +107,7 @@ func (c *ReleaseClient) populate() error {
 		return err
 	}
 
-	renderer := initRenderer()
+	renderer := initRenderer(c.officialInstance)
 	c.releases = make([]*Release, 0, len(githubReleases))
 	for _, r := range githubReleases {
 		if r.Prerelease || r.Draft {

--- a/src/pages/context.go
+++ b/src/pages/context.go
@@ -17,13 +17,14 @@ type RequestInfo interface {
 type ContextData map[string]interface{}
 
 type Context struct {
-	NakedContent bool
-	Page         *page
-	Sidebar      *page
-	NoBoost      bool
-	HotReload    bool
-	MainDomain   bool
-	RequestInfo  RequestInfo
+	NakedContent     bool
+	Page             *page
+	Sidebar          *page
+	NoBoost          bool
+	HotReload        bool
+	OfficialInstance bool
+	GreyLogo         bool
+	RequestInfo      RequestInfo
 
 	CurrentSection  string
 	NavigationLinks interface{}


### PR DESCRIPTION
Users in self-hosted instances will be interested in the full changelog, including changes not relevant to the main instance.

- introduce a new `--official-instance` option, that we'll set on letsblock.it domains
- when that option is true, truncate the changelog and add a link to the github releases page