### PR TITLE
Revert "youtube: expand all filters to support subscriptions list layout"

### DIFF
--- a/data/filters/youtube-mixes.yaml
+++ b/data/filters/youtube-mixes.yaml
@@ -3,7 +3,6 @@ tags:
   - youtube
 template: |
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[href*="&start_radio=1"])
-  www.youtube.com##ytd-browse ytd-item-section-renderer:has(#video-title-link[href*="&start_radio=1"])
   www.youtube.com##ytd-search ytd-radio-renderer
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
   www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
@@ -11,7 +10,6 @@ tests:
   - params: {}
     output: |
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[href*="&start_radio=1"])
-      www.youtube.com##ytd-browse ytd-item-section-renderer:has(#video-title-link[href*="&start_radio=1"])
       www.youtube.com##ytd-search ytd-radio-renderer
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
       www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]

--- a/data/filters/youtube-shorts.yaml
+++ b/data/filters/youtube-shorts.yaml
@@ -4,9 +4,12 @@ tags:
 template: |
   www.youtube.com###guide-content #endpoint[title="Shorts"]:upward(ytd-guide-entry-renderer)
   www.youtube.com###items #endpoint[title="Shorts"]:upward(ytd-mini-guide-entry-renderer)
+  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+  www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+  www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
   www.youtube.com##ytd-browse ytd-grid-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
-  www.youtube.com##ytd-browse ytd-item-section-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
   www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
 
@@ -14,13 +17,22 @@ tests:
   - output: |
       www.youtube.com###guide-content #endpoint[title="Shorts"]:upward(ytd-guide-entry-renderer)
       www.youtube.com###items #endpoint[title="Shorts"]:upward(ytd-mini-guide-entry-renderer)
+      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+      www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
+      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer:has-text(/\s(0:\d\d|1:0\d)\s/))
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
-      www.youtube.com##ytd-browse ytd-item-section-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
       www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
 ---
 
 Youtube shorts are more and more prevalent, and I don't care one bit about that format.
 
-This filter hides the navigation bar icon and shorts videos on all lists (homepage, subscriptions, search and sidebar).
+This filter hides the navigation bar icon and shorts videos on all lists (homepage, subscriptions, search and sidebar), with the two designs currently observed:
+
+- videos with the Shorts icon instead of a duration (new design)
+- videos shorter than 70 seconds (old design, currently phasing out). This rule can have false-positives, but also catches videos intended to be shorts by the creator, but too long to be classified as such.
+
+If you are concerned about false-positives, an alternative is to use the [Hide Youtube videos by title](/filters/youtube-video-title)
+filter, set to match on the `#shorts` and `#short` words.

--- a/data/filters/youtube-upcoming-videos.yaml
+++ b/data/filters/youtube-upcoming-videos.yaml
@@ -4,13 +4,11 @@ tags:
 template: |
   www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
-  www.youtube.com##ytd-browse ytd-item-section-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
 tests:
   - params: {}
     output: |
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
-      www.youtube.com##ytd-browse ytd-item-section-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
 ---
 Youtube gives enhanced visiblity to live streams, and many channels are abusing this by releasing regular videos as streams.
 

--- a/data/filters/youtube-video-title.yaml
+++ b/data/filters/youtube-video-title.yaml
@@ -10,7 +10,6 @@ template: |
   {{#each keywords}}
   www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="{{ . }}" i])
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="{{ . }}" i])
-  www.youtube.com##ytd-browse ytd-item-section-renderer:has(#video-title-link[title~="{{ . }}" i])
   www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="{{ . }}" i])
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="{{ . }}" i])
   {{/each}}
@@ -22,12 +21,10 @@ tests:
     output: |
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="lofi" i])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="lofi" i])
-      www.youtube.com##ytd-browse ytd-item-section-renderer:has(#video-title-link[title~="lofi" i])
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="lofi" i])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="lofi" i])
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="#shorts" i])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="#shorts" i])
-      www.youtube.com##ytd-browse ytd-item-section-renderer:has(#video-title-link[title~="#shorts" i])
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="#shorts" i])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="#shorts" i])
 ---


### PR DESCRIPTION
Revert letsblockit/letsblockit#200 because it causes a regression in the grid view layout: videos are now grouped by date, and one video matching a filter will hide the whole group due to the `ytd-item-section-renderer` rule.