### PR TITLE
youtube: expand filters to support subscriptions list layout (second try)

### DIFF
--- a/data/filters/youtube-shorts.yaml
+++ b/data/filters/youtube-shorts.yaml
@@ -12,6 +12,8 @@ template: |
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
   www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
+  {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"]:upward(ytd-item-section-renderer)
 
 tests:
   - output: |
@@ -25,6 +27,7 @@ tests:
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
       www.youtube.com##ytd-search ytd-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer span.ytd-thumbnail-overlay-time-status-renderer[aria-label="Shorts"]:upward(ytd-item-section-renderer)
 ---
 
 Youtube shorts are more and more prevalent, and I don't care one bit about that format.

--- a/data/filters/youtube-upcoming-videos.yaml
+++ b/data/filters/youtube-upcoming-videos.yaml
@@ -4,11 +4,14 @@ tags:
 template: |
   www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
+  {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]:upward(ytd-item-section-renderer)
 tests:
   - params: {}
     output: |
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]:upward(ytd-item-section-renderer)
 ---
 Youtube gives enhanced visiblity to live streams, and many channels are abusing this by releasing regular videos as streams.
 

--- a/data/filters/youtube-video-title.yaml
+++ b/data/filters/youtube-video-title.yaml
@@ -12,6 +12,8 @@ template: |
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="{{ . }}" i])
   www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="{{ . }}" i])
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="{{ . }}" i])
+  {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="{{ . }}" i]:upward(ytd-item-section-renderer)
   {{/each}}
 tests:
   - params: {}
@@ -23,10 +25,12 @@ tests:
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="lofi" i])
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="lofi" i])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="lofi" i])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="lofi" i]:upward(ytd-item-section-renderer)
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="#shorts" i])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="#shorts" i])
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="#shorts" i])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="#shorts" i])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="#shorts" i]:upward(ytd-item-section-renderer)
 ---
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this. With this filter, you can remove videos with a given word in their title.
 


### PR DESCRIPTION
Revisited version of #200, fixing the regression. Only doing the following templates for now:

- shorts
- upcoming
- by title

I am not sure whether mixes/radios can show in subscriptions.