### PR TITLE
google-search-cleanup: revamp filter to work with new design

### DIFF
--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -12,6 +12,10 @@ params:
     description: Hide the "Related searches" bottom content
     type: checkbox
     default: true
+  - name: also-search
+    description: Hide the "People also search for" popup shown when returning to results
+    type: checkbox
+    default: true
   - name: similar-image-searches
     description: Hide the "Similar searches" contextual content in image searches
     type: checkbox
@@ -39,6 +43,9 @@ template: |
   {{/if}}
   {{#if related-searches}}
   google.*###botstuff #bres
+  {{/if}}
+  {{#if also-search}}
+  google.*###rso div.g div[jscontroller][id^="eob_"]
   {{/if}}
   {{#if similar-image-searches}}
   google.*##div.isv-r[data-rfg]

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -3,7 +3,7 @@ params:
   - name: rich-results
     description: Hide most rich-content results (images, stories, businesses...) in the web search
     type: checkbox
-    default: false
+    default: true
   - name: related-questions
     description: Hide the "People also ask" contextual content
     type: checkbox
@@ -86,8 +86,18 @@ tests:
   - params: {}
 ---
 
-Google is adding more and more "contextual results" to its result page, with mixed usefulness. This filter will allow
-you to selectively remove these from the results, to only focus on the links.
+Google has dramatically decreased the information density of their search results, by mixing in more and more "Rich
+content" and contextual suggestions. This filter template helps reducing that noise, to focus on web pages only:
 
-Don't hesitate to [open a issue](https://github.com/letsblockit/letsblockit/issues/new/choose) to suggest additions or fixes ;
-and check out the [Hide websites from search results](search-results) filter too.
+- The first option removes most "Rich content" blocks (videos, images, maps, news...). You can still access these
+  results by going to the specific search pages
+- The other options remove the "related questions" / "related searches" prompts within and under the results,
+  for a denser layout
+- The last option hides your location from the page footer, for people with privacy concerns
+
+Another issue with Google search results is the amount of irrelevant websites that manage to get into the top results.
+To remove these, you should checkout the [Hide websites from search results](search-results) filter template too.
+
+As new contextual blocks are regularly added and modified, we expect some of them to pass through the filter, but
+don't hesitate to [open an issue](https://github.com/letsblockit/letsblockit/issues/new?labels=filter-data&template=update-filter.yaml&what_filter_does_this_issue_target=google-search-cleanup)
+to report them. Don't forget to add a screenshot and a search link to help us reproduce.

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -1,15 +1,15 @@
 title: Cleanup Google search result pages
 params:
+  - name: rich-results
+    description: Hide most rich-content results (images, stories, businesses...)
+    type: checkbox
+    default: true
   - name: related-questions
     description: Hide the "People also ask" contextual content
     type: checkbox
     default: true
   - name: related-searches
     description: Hide the "Related searches" bottom content
-    type: checkbox
-    default: true
-  - name: also-search
-    description: Hide the "People also search for" popup
     type: checkbox
     default: true
   - name: similar-image-searches
@@ -20,30 +20,31 @@ params:
     description: Hide the search page footer showing your address
     type: checkbox
     default: false
-  - name: only-results
-    description: Remove everything but simple results in the text search
-    type: checkbox
-    default: false
 tags:
   - google
 template: |
+  {{#if rich-results}}
+  !!! Toplevel rich content above columns
+  google.*###rcnt > div:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+  !!! Rich content in normal pages
+  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(>div g-more-link,g-scrolling-carousel)
+  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-section-with-header)
+  !!! Rich content in new "kp" layout
+  google.*###kp-wp-tab-overview > div:has(>div g-more-link,g-scrolling-carousel,#media_result_group)
+  google.*###kp-wp-tab-overview > div:has(g-section-with-header)
+  {{/if}}
   {{#if related-questions}}
-  google.*###rso > div:has(div.related-question-pair)
+  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+  google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
   {{/if}}
   {{#if related-searches}}
   google.*###botstuff #bres
-  {{/if}}
-  {{#if also-search}}
-  google.*###rso div.g div[jscontroller]
   {{/if}}
   {{#if similar-image-searches}}
   google.*##div.isv-r[data-rfg]
   {{/if}}
   {{#if page-footer}}
   google.*###footcnt > #fbarcnt
-  {{/if}}
-  {{#if only-results}}
-  google.*###rso > :not(div.g):not(:has(:scope>div.g))
   {{/if}}
 tests:
   - params: {}
@@ -52,31 +53,35 @@ tests:
       related-questions: true
       related-searches: true
     output: |
-      google.*###rso > div:has(div.related-question-pair)
+      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+      google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
       google.*###botstuff #bres
   - params:
-      also-search: true
+      rich-results: true
     output: |
-      google.*###rso div.g div[jscontroller]
+      !!! Toplevel rich content above columns
+      google.*###rcnt > div:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+      !!! Rich content in normal pages
+      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(>div g-more-link,g-scrolling-carousel)
+      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-section-with-header)
+      !!! Rich content in new "kp" layout
+      google.*###kp-wp-tab-overview > div:has(>div g-more-link,g-scrolling-carousel,#media_result_group)
+      google.*###kp-wp-tab-overview > div:has(g-section-with-header)
   - params:
-      related-questions: true
+      page-footer: true
       related-searches: true
-      only-results: true
     output: |
-      google.*###rso > div:has(div.related-question-pair)
       google.*###botstuff #bres
-      google.*###rso > :not(div.g):not(:has(:scope>div.g))
+      google.*###footcnt > #fbarcnt
   - params:
       similar-image-searches: true
     output: |
       google.*##div.isv-r[data-rfg]
+  - params: {}
 ---
 
 Google is adding more and more "contextual results" to its result page, with mixed usefulness. This filter will allow
 you to selectively remove these from the results, to only focus on the links.
-
-The last option (Remove everything but simple search results), will remove everything but simple `div.g` elements,
-removing images, videos, maps and most of other sections. It is disabled by default due to its greedy nature.
 
 Don't hesitate to [open a issue](https://github.com/letsblockit/letsblockit/issues/new/choose) to suggest additions or fixes ;
 and check out the [Hide websites from search results](search-results) filter too.

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -32,6 +32,8 @@ template: |
   google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   !!! Rich content in normal pages
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
+  !!! "Find results on" carousel
+  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
   !!! Rich content in new "kp" layout
   google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
@@ -68,6 +70,8 @@ tests:
       google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
       !!! Rich content in normal pages
       google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
+      !!! "Find results on" carousel
+      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
       !!! Rich content in new "kp" layout
       google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - params:

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -1,9 +1,9 @@
 title: Cleanup Google search result pages
 params:
   - name: rich-results
-    description: Hide most rich-content results (images, stories, businesses...)
+    description: Hide most rich-content results (images, stories, businesses...) in the web search
     type: checkbox
-    default: true
+    default: false
   - name: related-questions
     description: Hide the "People also ask" contextual content
     type: checkbox
@@ -28,13 +28,13 @@ tags:
   - google
 template: |
   {{#if rich-results}}
-  !!! Toplevel rich content above columns
+  {{! Toplevel rich content above columns }}
   google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
-  !!! Rich content in normal pages
+  {{! Rich content in normal pages }}
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
-  !!! "Find results on" carousel
+  {{! "Find results on" carousel }}
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
-  !!! Rich content in new "kp" layout
+  {{! New page layout for books / movies / shows, some rich elements are not handled yet }}
   google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
@@ -45,6 +45,7 @@ template: |
   google.*###botstuff #bres
   {{/if}}
   {{#if also-search}}
+  {{! These unfurl after clicking on a result and going back to the results page }}
   google.*###rso div.g div[jscontroller][id^="eob_"]
   {{/if}}
   {{#if similar-image-searches}}
@@ -66,13 +67,9 @@ tests:
   - params:
       rich-results: true
     output: |
-      !!! Toplevel rich content above columns
       google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
-      !!! Rich content in normal pages
       google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
-      !!! "Find results on" carousel
       google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
-      !!! Rich content in new "kp" layout
       google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - params:
       page-footer: true

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -33,7 +33,7 @@ template: |
   !!! Rich content in normal pages
   google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
   !!! Rich content in new "kp" layout
-  google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,#media_result_group,g-section-with-header)
+  google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
@@ -65,18 +65,18 @@ tests:
       rich-results: true
     output: |
       !!! Toplevel rich content above columns
-      google.*###rcnt > div:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+      google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
       !!! Rich content in normal pages
-      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(>div g-more-link,g-scrolling-carousel)
-      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-section-with-header)
+      google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
       !!! Rich content in new "kp" layout
-      google.*###kp-wp-tab-overview > div:has(>div g-more-link,g-scrolling-carousel,#media_result_group)
-      google.*###kp-wp-tab-overview > div:has(g-section-with-header)
+      google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,g-section-with-header,#media_result_group)
   - params:
       page-footer: true
       related-searches: true
+      also-search: true
     output: |
       google.*###botstuff #bres
+      google.*###rso div.g div[jscontroller][id^="eob_"]
       google.*###footcnt > #fbarcnt
   - params:
       similar-image-searches: true

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -31,11 +31,9 @@ template: |
   !!! Toplevel rich content above columns
   google.*###rcnt > div:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   !!! Rich content in normal pages
-  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(>div g-more-link,g-scrolling-carousel)
-  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-section-with-header)
+  google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
   !!! Rich content in new "kp" layout
-  google.*###kp-wp-tab-overview > div:has(>div g-more-link,g-scrolling-carousel,#media_result_group)
-  google.*###kp-wp-tab-overview > div:has(g-section-with-header)
+  google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,#media_result_group,g-section-with-header)
   {{/if}}
   {{#if related-questions}}
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -31,9 +31,9 @@ template: |
   !!! Toplevel rich content above columns
   google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   !!! Rich content in normal pages
-  google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
+  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
   !!! Rich content in new "kp" layout
-  google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,g-section-with-header,#media_result_group)
+  google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
   google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
@@ -67,9 +67,9 @@ tests:
       !!! Toplevel rich content above columns
       google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
       !!! Rich content in normal pages
-      google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
+      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
       !!! Rich content in new "kp" layout
-      google.*###kp-wp-tab-overview > div:has(g-more-link,g-scrolling-carousel,g-section-with-header,#media_result_group)
+      google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - params:
       page-footer: true
       related-searches: true

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -29,7 +29,7 @@ tags:
 template: |
   {{#if rich-results}}
   !!! Toplevel rich content above columns
-  google.*###rcnt > div:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+  google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   !!! Rich content in normal pages
   google.*###rso:not(:has(#kp-wp-tab-overview,video-voyager)) > div:has(g-more-link,g-scrolling-carousel,g-section-with-header)
   !!! Rich content in new "kp" layout

--- a/src/db/migrations/0006_google-search-cleanup-rich-content.up.sql
+++ b/src/db/migrations/0006_google-search-cleanup-rich-content.up.sql
@@ -1,0 +1,6 @@
+--- The only-results option has been deprecated, move instances to
+--- the new 'rich-results' option as a partial replacement for it.
+
+UPDATE filter_instances
+SET params = filter_instances.params || jsonb_build_object('rich-results', true)
+WHERE filter_name = 'google-search-cleanup' AND filter_instances.params -> 'only-results' = 'true';


### PR DESCRIPTION
Rework the "Cleanup Google search result pages" filters to hopefully address these issues:

- Fixes #219: the "only-results" options breaks News and Shopping pages because it is way too greedy (this is why it was disabled by default). I decided to discontinue it, and replace it by more selective rules. The new "rich-results" is more focused and catches most non-text results while being more reliable. More rules will be added later as we iterate to match more elements
- Fixes #170: pages about cultural works (books, movies...) have a new layout with a `#kp-wp-tab-cont-overview` element, that results in empty pages with the "related-questions", "also-search" and "only-results" options. Impossible to support both layouts with a single rule, so affected rules are duplicated and a variant is chosen based on the presence or not of a `#kp-wp-tab-cont-overview` element. We made the "also-search" option more selective to avoid false-positives.
- Fixes #222: this kind of result is on a separate toplevel section, outside of `#rso`. A specific rule for them is added to the new "rich-results" option

All users of the deprecated "only-results" option will have new "rich-results" option enabled automatically, as will new users. Other users will be encouraged to enable it by a green `new` badge alongside it. Testing and feedback on these is highly welcome, before I dare release it! You can test their impact with the following rules, modified to add a color border around matching elements instead of hiding them, to detect false positives:

```

!!! Toplevel rich content above columns
google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel):style(border: 2px dashed orange !important)
!!! Rich content in normal pages
google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header):style(border: 2px dashed red !important)
!!! Rich content in new "kp" layout
google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group):style(border: 2px dashed red !important)
!!! Find results on carousel
google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel):style(border: 2px dashed orange !important

!!! Related questions, with normal and kp layout
google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair):style(border: 2px dashed green !important)
google.*###kp-wp-tab-overview > div:has(div.related-question-pair):style(border: 2px dashed green !important)
!!! More selective also-search for popup when returning to results
google.*###rso div.g div[jscontroller][id^="eob_"]:style(border: 2px dashed purple !important)

!!! Unchanged existing rules
google.*###botstuff #bres:style(border: 2px dashed blue !important)
google.*##div.isv-r[data-rfg]:style(border: 2px dashed blue !important)

```

@3DWORX-SA, @pitsi, @koitsu, I'd love your feedback on these rules.