### PR TITLE
prompt the user to re-install their list on filter list

### DIFF
--- a/data/pages/list-filters.hbs
+++ b/data/pages/list-filters.hbs
@@ -23,12 +23,18 @@
     </div>
     <div class="col col-lg-10">
         {{#if active_filters }}
-            {{#unless list_downloaded }}
+            {{#if list_downloaded }}
+                <div id="install-prompt-{{list_token}}" role="alert" aria-hidden="true"
+                     class="alert alert-secondary has-background-secondary-light">
+                    Your list is not installed on this browser, follow these instructions to
+                    <a href="{{href "help" "use-list"}}">add your list to uBlock Origin</a>.
+                </div>
+            {{else}}
                 <div role="alert" class="alert alert-secondary has-background-secondary-light">
                     Now that you have setup some filters,
-                    <a href="{{href "help" "use-list"}}">add your list to uBlock</a> to use them.
+                    <a href="{{href "help" "use-list"}}">add your list to uBlock Origin</a> to use them.
                 </div>
-            {{/unless}}
+            {{/if}}
             <h2>Active filter templates{{#if tag_search}} with tag <em>{{tag_search}}</em>{{/if}}</h2>
             <div>
                 These filters are active in <a href="{{href "help" "use-list"}}">your personal list</a>.

--- a/src/server/filters.go
+++ b/src/server/filters.go
@@ -50,8 +50,10 @@ func (s *Server) listFilters(c echo.Context) error {
 			}
 		}
 		if len(instances) > 0 {
-			downloaded, _ := s.store.HasUserDownloadedList(c.Request().Context(), hc.UserID)
-			hc.Add("list_downloaded", downloaded)
+			if info, err := s.store.GetListForUser(c.Request().Context(), hc.UserID); err == nil {
+				hc.Add("list_token", info.Token.String())
+				hc.Add("list_downloaded", info.Downloaded)
+			}
 		}
 		if len(updatedFilters) > 0 {
 			hc.Add("updated_filters", updatedFilters)

--- a/src/server/filters_test.go
+++ b/src/server/filters_test.go
@@ -62,7 +62,7 @@ func (s *ServerTestSuite) TestListFilters_OK() {
 
 	require.NoError(s.T(), s.server.upsertFilterParams(s.c, s.user, &filters.Instance{Filter: "filter1", TestMode: true}))
 	require.NoError(s.T(), s.server.upsertFilterParams(s.c, s.user, &filters.Instance{Filter: "filter2"}))
-	s.markListDownloaded()
+	token := s.markListDownloaded()
 
 	s.expectRender("list-filters", pages.ContextData{
 		"filter_tags":       filterTags,
@@ -70,6 +70,7 @@ func (s *ServerTestSuite) TestListFilters_OK() {
 		"available_filters": []*filters.Filter{filter3},
 		"testing_filters":   map[string]bool{"filter1": true},
 		"list_downloaded":   true,
+		"list_token":        token,
 		"updated_filters":   map[string]bool{"filter2": true},
 	})
 	s.runRequest(req, assertOk)
@@ -79,12 +80,16 @@ func (s *ServerTestSuite) TestListFilters_ByTag() {
 	req := httptest.NewRequest(http.MethodGet, "/filters/tag/tag2", nil)
 
 	require.NoError(s.T(), s.server.upsertFilterParams(s.c, s.user, &filters.Instance{Filter: "filter1"}))
+	list, err := s.store.GetListForUser(context.Background(), s.user)
+	require.NoError(s.T(), err)
+
 	s.expectRender("list-filters", pages.ContextData{
 		"filter_tags":       filterTags,
 		"tag_search":        "tag2",
 		"active_filters":    []*filters.Filter{filter1},
 		"available_filters": []*filters.Filter{filter2},
 		"list_downloaded":   false,
+		"list_token":        list.Token.String(),
 	})
 	s.runRequest(req, assertOk)
 }

--- a/src/server/suite_test.go
+++ b/src/server/suite_test.go
@@ -147,11 +147,12 @@ func (s *ServerTestSuite) setUserBanned() {
 	s.server.bans, _ = users.LoadUserBans(s.server.store)
 }
 
-func (s *ServerTestSuite) markListDownloaded() {
+func (s *ServerTestSuite) markListDownloaded() string {
 	s.T().Helper()
 	list, err := s.store.GetListForUser(context.Background(), s.user)
 	require.NoError(s.T(), err)
 	require.NoError(s.T(), s.store.MarkListDownloaded(context.Background(), list.Token))
+	return list.Token.String()
 }
 
 func (s *ServerTestSuite) expectRender(page string, data pages.ContextData) *gomock.Call {


### PR DESCRIPTION
The alert is always present, hidden by a cosmetic filter injected in your list. Hidden from screen readers with aria-hidden. The rule has been served for more than a week now, it should be safe to use.

This will be helpful for users installing the list on several browsers, or failing to find the install instructions after resetting their browser / adblocker configuration.