### PR TITLE
Restrict Google search rules to www.google.com domain

### DIFF
--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -29,30 +29,30 @@ tags:
 template: |
   {{#if rich-results}}
   {{! Toplevel rich content above columns }}
-  google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+  www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   {{! Rich content in normal pages }}
-  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
+  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
   {{! "Find results on" carousel }}
-  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
+  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
   {{! New page layout for books / movies / shows, some rich elements are not handled yet }}
-  google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
+  www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
-  google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
-  google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
+  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+  www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
   {{/if}}
   {{#if related-searches}}
-  google.*###botstuff #bres
+  www.google.*###botstuff #bres
   {{/if}}
   {{#if also-search}}
   {{! These unfurl after clicking on a result and going back to the results page }}
-  google.*###rso div.g div[jscontroller][id^="eob_"]
+  www.google.*###rso div.g div[jscontroller][id^="eob_"]
   {{/if}}
   {{#if similar-image-searches}}
-  google.*##div.isv-r[data-rfg]
+  www.google.*##div.isv-r[data-rfg]
   {{/if}}
   {{#if page-footer}}
-  google.*###footcnt > #fbarcnt
+  www.google.*###footcnt > #fbarcnt
   {{/if}}
 tests:
   - params: {}
@@ -61,28 +61,28 @@ tests:
       related-questions: true
       related-searches: true
     output: |
-      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
-      google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
-      google.*###botstuff #bres
+      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+      www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
+      www.google.*###botstuff #bres
   - params:
       rich-results: true
     output: |
-      google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
-      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
-      google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
-      google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
+      www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
+      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
+      www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - params:
       page-footer: true
       related-searches: true
       also-search: true
     output: |
-      google.*###botstuff #bres
-      google.*###rso div.g div[jscontroller][id^="eob_"]
-      google.*###footcnt > #fbarcnt
+      www.google.*###botstuff #bres
+      www.google.*###rso div.g div[jscontroller][id^="eob_"]
+      www.google.*###footcnt > #fbarcnt
   - params:
       similar-image-searches: true
     output: |
-      google.*##div.isv-r[data-rfg]
+      www.google.*##div.isv-r[data-rfg]
   - params: {}
 ---
 

--- a/data/filters/search-results.yaml
+++ b/data/filters/search-results.yaml
@@ -563,8 +563,8 @@ template: |
   bing.com###b_content a[href*="{{site}}"]:upward(li)
   {{/if}}
   {{#if ../google}}
-  google.*##.g:has(a[href*="{{site}}"])
-  google.*##a[href*="{{site}}"]:upward(1)
+  www.google.*##.g:has(a[href*="{{site}}"])
+  www.google.*##a[href*="{{site}}"]:upward(1)
   {{/if}}
   {{#if ../duckduckgo}}
   duckduckgo.com##a[data-testid="result-title-a"][href*="{{site}}"]:upward(.nrn-react-div)
@@ -607,15 +607,15 @@ tests:
       startpage: true
     output: |
       bing.com###b_content a[href*=".pinterest."]:upward(li)
-      google.*##.g:has(a[href*=".pinterest."])
-      google.*##a[href*=".pinterest."]:upward(1)
+      www.google.*##.g:has(a[href*=".pinterest."])
+      www.google.*##a[href*=".pinterest."]:upward(1)
       duckduckgo.com##a[data-testid="result-title-a"][href*=".pinterest."]:upward(.nrn-react-div)
       duckduckgo.com##.tile-wrap a[href*=".pinterest."]:upward(.tile)
       startpage.com##.w-gl__result:has(a[href*=".pinterest."])
       startpage.com##.image-container:has(div.image-quick-details span:has-text(.pinterest.))
       bing.com###b_content a[href*="snapcraft.io/install"]:upward(li)
-      google.*##.g:has(a[href*="snapcraft.io/install"])
-      google.*##a[href*="snapcraft.io/install"]:upward(1)
+      www.google.*##.g:has(a[href*="snapcraft.io/install"])
+      www.google.*##a[href*="snapcraft.io/install"]:upward(1)
       duckduckgo.com##a[data-testid="result-title-a"][href*="snapcraft.io/install"]:upward(.nrn-react-div)
       duckduckgo.com##.tile-wrap a[href*="snapcraft.io/install"]:upward(.tile)
       startpage.com##.w-gl__result:has(a[href*="snapcraft.io/install"])


### PR DESCRIPTION
Closes #237, make sure google search rules do not apply to other google subdomains.

I could not find a use case that does not have the `www` subdomain, but we will revert this PR if it breaks for some users.