### PR TITLE
Add .txt suffix to list download links

### DIFF
--- a/src/server/help.go
+++ b/src/server/help.go
@@ -78,7 +78,7 @@ func (s *Server) helpPages(c echo.Context) error {
 			listUrl := url.URL{
 				Scheme: c.Scheme(),
 				Host:   c.Request().Host,
-				Path:   c.Echo().Reverse("render-filterlist", info.Token.String()),
+				Path:   c.Echo().Reverse("render-filterlist", info.Token.String()) + renderListSuffix,
 			}
 			if s.options.ListDownloadDomain != "" {
 				listUrl.Host = s.options.ListDownloadDomain

--- a/src/server/help_test.go
+++ b/src/server/help_test.go
@@ -27,7 +27,7 @@ func (s *ServerTestSuite) TestHelpUseList_OK() {
 	req := httptest.NewRequest(http.MethodGet, "http://myhost/help/use-list", nil)
 	s.expectRenderWithSidebar("help-use-list", "help-sidebar", pages.ContextData{
 		"has_filters":   false,
-		"list_url":      fmt.Sprintf("http://myhost/list/%s", token.String()),
+		"list_url":      fmt.Sprintf("http://myhost/list/%s.txt", token.String()),
 		"page":          helpMenu[0].Pages[0],
 		"menu_sections": helpMenu,
 	})
@@ -43,7 +43,7 @@ func (s *ServerTestSuite) TestHelpUseList_DownloadDomainOK() {
 	s.server.options.ListDownloadDomain = "get.letsblock.it"
 	s.expectRenderWithSidebar("help-use-list", "help-sidebar", pages.ContextData{
 		"has_filters":   true,
-		"list_url":      fmt.Sprintf("https://get.letsblock.it/list/%s", token.String()),
+		"list_url":      fmt.Sprintf("https://get.letsblock.it/list/%s.txt", token.String()),
 		"page":          helpMenu[0].Pages[0],
 		"menu_sections": helpMenu,
 	})

--- a/src/server/list.go
+++ b/src/server/list.go
@@ -23,13 +23,14 @@ const listExportTemplate = `# letsblock.it filter list export
 
 `
 
+const renderListSuffix = ".txt"
 const installPromptFilterTemplate = `
 ! Hide the list install prompt for that list
 %s###install-prompt-%s
 `
 
 func (s *Server) renderList(c echo.Context) error {
-	token, err := uuid.Parse(strings.TrimSuffix(c.Param("token"), ".txt"))
+	token, err := uuid.Parse(strings.TrimSuffix(c.Param("token"), renderListSuffix))
 	if err != nil {
 		return err
 	}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -194,7 +194,6 @@ func (s *Server) setupRouter() {
 	anon := s.echo.Group("")
 	anon.GET("/assets/*", echo.WrapHandler(statigz.FileServer(data.Assets)))
 	anon.GET("/list/:token", s.renderList).Name = "render-filterlist"
-	anon.GET("/list/:token", s.renderList).Name = "render-filterlist"
 	anon.POST("/filters/:name/render", s.viewFilterRender).Name = "view-filter-render"
 	anon.GET("/should-reload", shouldReload)
 	anon.GET("/news.atom", s.newsAtomHandler).Name = "news-atom"


### PR DESCRIPTION
As a follow-up to https://github.com/letsblockit/letsblockit/pull/243, generate list URLs with the `.txt` suffix for adguard compatiblity.

We'll still support the extension-less URL for compatibility of course.