### PR TITLE
youtube-recommendations: add option to hide the endscreen grid

### DIFF
--- a/data/filters/youtube-recommendations.yaml
+++ b/data/filters/youtube-recommendations.yaml
@@ -12,6 +12,10 @@ params:
     description: Hide video suggestions that obscure the end of the video
     type: checkbox
     default: true
+  - name:  endscreen-content
+    description: Hide the video grid shown after a video ends
+    type: checkbox
+    default: true
 tags:
   - youtube
 attribution:
@@ -25,6 +29,9 @@ template: |
   {{/if}}
   {{#if end-of-video-overlay}}
   www.youtube.com##.ytp-ce-element
+  {{/if}}
+  {{#if endscreen-content}}
+  www.youtube.com##.ytp-endscreen-content
   {{/if}}
 tests:
   - params: {}


### PR DESCRIPTION
Hides the grid of videos that youtube shows after the video ends.