### PR TITLE
google-search-cleanup: fix false-positive on new news layout

### DIFF
--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -31,14 +31,14 @@ template: |
   {{! Toplevel rich content above columns }}
   www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   {{! Rich content in normal pages }}
-  www.google.*###rso > div:not(:only-child):has(g-more-link,g-section-with-header)
+  www.google.*###rso:has(> div:nth-of-type(6)) > div:has(g-more-link,g-section-with-header)
   {{! "Find results on" carousel }}
-  www.google.*###rso > div:not(:only-child):has(div[role="heading"]+g-scrolling-carousel)
+  www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div[role="heading"]+g-scrolling-carousel)
   {{! New page layout for books / movies / shows, some rich elements are not handled yet }}
   www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
-  www.google.*###rso > div:not(:only-child):has(div.related-question-pair)
+  www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div.related-question-pair)
   www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
   {{/if}}
   {{#if related-searches}}
@@ -61,15 +61,15 @@ tests:
       related-questions: true
       related-searches: true
     output: |
-      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+      www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div.related-question-pair)
       www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
       www.google.*###botstuff #bres
   - params:
       rich-results: true
     output: |
       www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
-      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
-      www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
+      www.google.*###rso:has(> div:nth-of-type(6)) > div:has(g-more-link,g-section-with-header)
+      www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div[role="heading"]+g-scrolling-carousel)
       www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - params:
       page-footer: true

--- a/data/filters/google-search-cleanup.yaml
+++ b/data/filters/google-search-cleanup.yaml
@@ -31,14 +31,14 @@ template: |
   {{! Toplevel rich content above columns }}
   www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
   {{! Rich content in normal pages }}
-  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(g-more-link,g-section-with-header)
+  www.google.*###rso > div:not(:only-child):has(g-more-link,g-section-with-header)
   {{! "Find results on" carousel }}
-  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div[role="heading"]+g-scrolling-carousel)
+  www.google.*###rso > div:not(:only-child):has(div[role="heading"]+g-scrolling-carousel)
   {{! New page layout for books / movies / shows, some rich elements are not handled yet }}
   www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
-  www.google.*###rso:not(:has(#kp-wp-tab-overview)) > div:has(div.related-question-pair)
+  www.google.*###rso > div:not(:only-child):has(div.related-question-pair)
   www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
   {{/if}}
   {{#if related-searches}}


### PR DESCRIPTION
Fixes https://github.com/letsblockit/letsblockit/issues/219 after another layout change.

A new layout was deployed for movies / books / actors, that was completely blocked by the "Hide most rich-content results (images, stories, businesses...) in the web search" option. https://github.com/letsblockit/letsblockit/pull/223 fixed this by looking for the `#kp-wp-tab-overview` element and duplicating the rules for the two general & "cultural works" layout.

Some news results use a similar deeply-nested layout that also creates a false-positive with the rules for the general layout. This PR changes the rules for the general layout, by making them positively match the old layout (with a pretty inefficient but more robust `#rso:has(> div:nth-of-type(6))`), which should make sure new deeply nested layouts are not matched in the future.

This means "rich results" will not be removed on pages with this new layout, but we'll address that later on. We need a way to find the root `div` holding the organic results (`#rso` in old layout, `#kp-wp-tab-overview` for the cultural works layout, but other layouts don't have a clearly identified root `div`, and the class names are minified). Once we find a CSS rule that can detect this, we should be able to fold back the `#kp-wp-tab-overview` case.

An alternative would be to stop using such greedy rules, and instead go with a collection of very specific rules, targeting precisely each rich content type. This option looks more and more attractive.