### PR TITLE
ory: allow GETs on /user/action/loginOrRegistration

### DIFF
--- a/src/users/auth/ory.go
+++ b/src/users/auth/ory.go
@@ -135,6 +135,7 @@ func NewOryBackend(rootUrl string, renderer renderer, statsd statsd.ClientInterf
 func (o *OryBackend) RegisterRoutes(group EchoRouter) {
 	group.GET("/user/forms/:type", o.renderKratosForm)
 	group.POST("/user/action/:type", o.startKratosFlow).Name = userActionRouteName
+	group.GET("/user/action/loginOrRegistration", o.startLoginFlow).Name = "simple-login-link"
 }
 
 // BuildMiddleware tries to resolve an Ory Cloud session from the cookies.
@@ -264,6 +265,12 @@ func (o *OryBackend) startKratosFlow(c echo.Context) error {
 		}
 	}
 	return o.renderer.Redirect(c, http.StatusSeeOther, redirect)
+}
+
+func (o *OryBackend) startLoginFlow(c echo.Context) error {
+	c.SetParamNames("type")
+	c.SetParamValues("loginOrRegistration")
+	return o.startKratosFlow(c)
 }
 
 func (o *OryBackend) queryKratos(c echo.Context, typeTag, endpoint string, body interface{}) error {

--- a/src/users/auth/ory_test.go
+++ b/src/users/auth/ory_test.go
@@ -303,6 +303,22 @@ func (s *OryBackendSuite) TestStartKratosFlow_Logout() {
 	s.runRequest(req, assertOk)
 }
 
+func (s *OryBackendSuite) TestStartLoginFlow_Register() {
+	req := httptest.NewRequest(http.MethodGet, "/user/action/loginOrRegistration", nil)
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/registration/browser")
+	s.runRequest(req, assertOk)
+}
+
+func (s *OryBackendSuite) TestStartLoginFlow_Login() {
+	req := httptest.NewRequest(http.MethodGet, "/user/action/loginOrRegistration", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "has_account",
+		Value: "true",
+	})
+	s.expectP.Redirect(gomock.Any(), 303, s.kratosServer.URL+"/self-service/login/browser")
+	s.runRequest(req, assertOk)
+}
+
 func TestOryBackendSuite(t *testing.T) {
 	suite.Run(t, new(OryBackendSuite))
 }


### PR DESCRIPTION
Following Ory's recommendations, starting Kratos flows requires a `POST` request to protect against CSRF attacks.

The login / registration flows are less sensitive than the others, so let's add a `GET` handler alias, to address https://github.com/letsblockit/letsblockit/issues/270

Users can bookmark https://letsblock.it/user/action/loginOrRegistration to get on the login form. If their session is active, they are redirected to the homepage anyway.