### PR TITLE
youtube-cleanup: update copyright-notice rule for new layout

### DIFF
--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -92,7 +92,7 @@ tests:
     output: |
       www.youtube.com##[class*="video-secondary-info-renderer"] #always-shown + #collapsible
       www.youtube.com##[class*="video-secondary-info-renderer"] > #items:has(.ytd-video-description-music-section-renderer)
-      www.youtube.com###description-and-actions #always-shown + #collapsible
+      www.youtube.com###description .ytd-watch-metadata #items:has(.ytd-video-description-music-section-renderer)
   - params:
       remove-stream-chat: true
     output: |

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -52,7 +52,7 @@ template: |
   {{#if remove-copyright-notice}}
   www.youtube.com##[class*="video-secondary-info-renderer"] #always-shown + #collapsible
   www.youtube.com##[class*="video-secondary-info-renderer"] > #items:has(.ytd-video-description-music-section-renderer)
-  www.youtube.com###description-and-actions #always-shown + #collapsible
+  www.youtube.com###description .ytd-watch-metadata #items:has(.ytd-video-description-music-section-renderer)
   {{/if}}
   {{#if remove-stream-chat}}
   www.youtube.com###chat:remove()


### PR DESCRIPTION
copyright-notice: the other rule does not exist anymore

<details><summary>Working rule print-screen</summary>

![afbeelding](https://user-images.githubusercontent.com/81161435/199741964-7ddac121-243a-462f-86da-34bca40f56bd.png)

</details> 

<details><summary>NOT working rule print-screen</summary>

![afbeelding](https://user-images.githubusercontent.com/81161435/199742210-07931ddf-7db9-44e0-898a-892e2981b8cc.png)

</details> 