### PR TITLE
ci: post filter linting output as comment on PRs

### DIFF
--- a/.github/filter-lint-failed.md
+++ b/.github/filter-lint-failed.md
@@ -1,10 +1,9 @@
 Thanks for your contribution!
 
-Unfortunately, the automated tests failed. Please check the output below and
-[the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
-to fix these. Don't hesitate to comment if you need help making sense of the errors!
+Unfortunately, the automated tests failed. Please check the output below and [the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md) to fix these.
+Don't hesitate to comment if you need help addressing these failures!
 
 ### Test output:
 ```
-${output}
+$OUTPUT
 ```

--- a/.github/filter-lint-failed.md
+++ b/.github/filter-lint-failed.md
@@ -1,0 +1,10 @@
+Thanks for your contribution!
+
+Unfortunately, the automated tests failed. Please check the output below and
+[the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
+to fix these. Don't hesitate to comment if you need help making sense of the errors!
+
+### Test output:
+```
+${output}
+```

--- a/.github/filter-lint-ok.md
+++ b/.github/filter-lint-ok.md
@@ -1,0 +1,1 @@
+Thanks for your contribution! The automated tests passed, we will review your PR shortly!

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -1,8 +1,6 @@
 name: "Filter linting"
 on:
   pull_request:
-    paths:
-      - 'data/filters/**'
 jobs:
   filter-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -1,10 +1,12 @@
 name: "Filter linting"
 on:
   pull_request:
+    paths:
+      - 'data/filters/**'
 jobs:
   filter-lint:
     runs-on: ubuntu-latest
-    if: github.repository == 'letsblockit/letsblockit'
+#    if: github.repository == 'letsblockit/letsblockit'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -13,7 +13,13 @@ jobs:
       - name: Run linting and save output
         run: |
           cat <<EOF >>output.txt
-            Tests failed:
+            Thanks for your contribution!
+          
+            Unfortunately, the automated tests failed. Please check the output below and
+            [the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
+            to fix these. Don't hesitate to comment if you need help making sense of the errors!
+            
+            ### Test output:
             ```
           EOF
           go test ./src/filters/ >> output.txt
@@ -26,7 +32,7 @@ jobs:
         with:
           header: filter-lint
           message: |
-            Tests OK
+            Thanks for your contribution! The automated tests passed, we will review your PR shortly!
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Failure report generation
         if: ${{ failure() }}
         run: |
-          OUTPUT=$(cat output.txt) cat .github/filter-lint-failed.md | envsubst > report.md
+          OUTPUT=$(cat output.txt)
+          echo $OUTPUT
+          cat .github/filter-lint-failed.md | envsubst > report.md
+          cat report.md
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-go@v3
       - name: Run linting and save output
         run: |
+          fence='```'
           cat <<EOF >>output.txt
             Thanks for your contribution!
           
@@ -20,11 +21,11 @@ jobs:
             to fix these. Don't hesitate to comment if you need help making sense of the errors!
             
             ### Test output:
-            ```
+            ${fence}
           EOF
           go test ./src/filters/ >> output.txt
           cat <<EOF >>output.txt
-            ```
+            ${fence}
           EOF
       - name: Comment on success
         if: ${{ success() }}

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -13,34 +13,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
       - name: Run linting and save output
-        run: |
-          cat <<EOF >>output.txt
-          Thanks for your contribution!
-          
-          Unfortunately, the automated tests failed. Please check the output below and
-          [the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
-          to fix these. Don't hesitate to comment if you need help making sense of the errors!
-            
-          ### Test output:
-          ${CODEBLOCK_FENCE}
-          EOF
-          go test ./src/filters/ >> output.txt
+        run: go test ./src/filters/ >> output.txt
       - name: Comment on success
         if: ${{ success() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: filter-lint
-          message: |
-            Thanks for your contribution! The automated tests passed, we will review your PR shortly!
-      - name: Failure report footer
+          path: .github/filter-lint-ok.md
+      - name: Failure report generation
         if: ${{ failure() }}
         run: |
-          cat <<EOF >>output.txt
-          ${CODEBLOCK_FENCE}
-          EOF
+          output=`cat output.txt`
+          cat .github/filter-lint-failed.md | envsubst > report.md
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: filter-lint
-          path: output.txt
+          path: report.md

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
       - name: Run linting and save output
-        run: go test ./src/filters/ >> output.txt
+        run: go test ./src/filters/ > output.txt
       - name: Comment on success
         if: ${{ success() }}
         uses: marocchino/sticky-pull-request-comment@v2
@@ -23,8 +23,7 @@ jobs:
       - name: Failure report generation
         if: ${{ failure() }}
         run: |
-          output=`cat output.txt`
-          cat .github/filter-lint-failed.md | envsubst > report.md
+          OUTPUT=$(cat output.txt) cat .github/filter-lint-failed.md | envsubst > report.md
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   filter-lint:
     runs-on: ubuntu-latest
-#    if: github.repository == 'letsblockit/letsblockit'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - 'data/filters/**'
-env:
-  CODEBLOCK_FENCE: "```"
 jobs:
   filter-lint:
     runs-on: ubuntu-latest
@@ -23,10 +21,8 @@ jobs:
       - name: Failure report generation
         if: ${{ failure() }}
         run: |
-          OUTPUT=$(cat output.txt)
-          echo $OUTPUT
+          export OUTPUT=$(cat output.txt)
           cat .github/filter-lint-failed.md | envsubst > report.md
-          cat report.md
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -1,0 +1,31 @@
+name: "Filter linting"
+on:
+  pull_request:
+    paths:
+      - 'data/filters/**'
+jobs:
+  filter-lint:
+    runs-on: ubuntu-latest
+    if: github.repository == 'letsblockit/letsblockit'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+      - name: Run linting and save output
+        run: |
+          cat <<EOF >>output.txt
+            Tests failed:
+          EOF
+          go test ./src/filters/ >> output.txt
+      - name: Comment on success
+        if: ${{ success() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: filter-lint
+          message: |
+            Tests OK
+      - name: Comment on failure
+        if: ${{ failure() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: filter-lint
+          path: output.txt

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -14,8 +14,12 @@ jobs:
         run: |
           cat <<EOF >>output.txt
             Tests failed:
+            ```
           EOF
           go test ./src/filters/ >> output.txt
+          cat <<EOF >>output.txt
+            ```
+          EOF
       - name: Comment on success
         if: ${{ success() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - 'data/filters/**'
+env:
+  CODEBLOCK_FENCE: "```"
 jobs:
   filter-lint:
     runs-on: ubuntu-latest
@@ -12,7 +14,6 @@ jobs:
       - uses: actions/setup-go@v3
       - name: Run linting and save output
         run: |
-          fence='```'
           cat <<EOF >>output.txt
             Thanks for your contribution!
           
@@ -21,12 +22,9 @@ jobs:
             to fix these. Don't hesitate to comment if you need help making sense of the errors!
             
             ### Test output:
-            ${fence}
+            ${CODEBLOCK_FENCE}
           EOF
           go test ./src/filters/ >> output.txt
-          cat <<EOF >>output.txt
-            ${fence}
-          EOF
       - name: Comment on success
         if: ${{ success() }}
         uses: marocchino/sticky-pull-request-comment@v2
@@ -34,6 +32,12 @@ jobs:
           header: filter-lint
           message: |
             Thanks for your contribution! The automated tests passed, we will review your PR shortly!
+      - name: Failure report footer
+        if: ${{ failure() }}
+        run: |
+          cat <<EOF >>output.txt
+            ${CODEBLOCK_FENCE}
+          EOF
       - name: Comment on failure
         if: ${{ failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/filter-lint.yml
+++ b/.github/workflows/filter-lint.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Run linting and save output
         run: |
           cat <<EOF >>output.txt
-            Thanks for your contribution!
+          Thanks for your contribution!
           
-            Unfortunately, the automated tests failed. Please check the output below and
-            [the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
-            to fix these. Don't hesitate to comment if you need help making sense of the errors!
+          Unfortunately, the automated tests failed. Please check the output below and
+          [the syntax documentation](https://github.com/letsblockit/letsblockit/blob/main/data/filters/README.md)
+          to fix these. Don't hesitate to comment if you need help making sense of the errors!
             
-            ### Test output:
-            ${CODEBLOCK_FENCE}
+          ### Test output:
+          ${CODEBLOCK_FENCE}
           EOF
           go test ./src/filters/ >> output.txt
       - name: Comment on success
@@ -36,7 +36,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           cat <<EOF >>output.txt
-            ${CODEBLOCK_FENCE}
+          ${CODEBLOCK_FENCE}
           EOF
       - name: Comment on failure
         if: ${{ failure() }}


### PR DESCRIPTION
New workflow running on PRs changing the `data/filters/` contents. It runs the input validation tests and keeps one comment updated with its output. Hopefully, this will be helpful to contributors by:

- surfacing the failures without requiring to dig into the CI logs
- linking to the syntax documentation, that we'll need to improve over time