### PR TITLE
youtube-watched: fix use of channel rule without homepage

### DIFF
--- a/data/filters/youtube-watched.yaml
+++ b/data/filters/youtube-watched.yaml
@@ -24,10 +24,13 @@ params:
     default: false
 template: |
   {{#if homepage}}
-  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
+  www.youtube.com##ytd-browse[page-subtype="home"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
   {{/if}}
   {{#if subscriptions}}
-  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
+  www.youtube.com##ytd-browse[page-subtype="channels"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
+  www.youtube.com##ytd-browse[page-subtype="channels"] ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
+  {{! Subscriptions in grid mode }}
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}})
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-resume-playback-renderer{{#if only-fully}} #progress[style="width: 100%;"]{{/if}}:upward(ytd-item-section-renderer)
   {{/if}}
@@ -43,8 +46,10 @@ tests:
       homepage: true
       subscriptions: true
     output: |
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
-      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
+      www.youtube.com##ytd-browse[page-subtype="home"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
+      www.youtube.com##ytd-browse[page-subtype="channels"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
+      www.youtube.com##ytd-browse[page-subtype="channels"] ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-grid-video-renderer:has(ytd-thumbnail-overlay-resume-playback-renderer)
       www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-resume-playback-renderer:upward(ytd-item-section-renderer)
   - params:
       only-fully: true


### PR DESCRIPTION
Fixes https://github.com/letsblockit/letsblockit/issues/306 and https://github.com/letsblockit/letsblockit/issues/304

The issue is that the homepage rule was not specific enough, and matching one type of video in the channel page. Using the channel rule without the homepage rule would not completely work, but a user setting both rules on could not reproduce the issue.

Duplicate the `ytd-rich-item-renderer` rule for both options, with a specific `page-subtype` filter like we do in other templates.