### PR TITLE
youtube-search-cleanup: add new template

### DIFF
--- a/data/filters/templates/youtube-search-cleanup.yaml
+++ b/data/filters/templates/youtube-search-cleanup.yaml
@@ -1,0 +1,12 @@
+title: Cleanup the YouTube search results
+tags:
+  - youtube
+template: |
+  {{! Non organic results such as For You, Previously Watched, People Also Watched... }}
+  www.youtube.com##ytd-search ytd-item-section-renderer ytd-shelf-renderer:style(border: 2px dashed red !important)
+  {{! Related searches }}
+  www.youtube.com##ytd-search ytd-item-section-renderer ytd-horizontal-card-list-renderer:style(border: 2px dashed red !important)
+---
+
+These rules remove related searches and related results from the YouTube search results, only leaving organic
+matches for your search.


### PR DESCRIPTION
Closes #338 

Made the template non-configurable for now, if requested we can decouple the two rules with parameters later. No need to mobile rules, as only organic results seem to be shown to mobile devices.