### PR TITLE
youtube-video-title: improve word matching

### DIFF
--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -30,7 +30,7 @@ tests:
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="#shorts" i])
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="#shorts" i])
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="#shorts" i])
-      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*~="#shorts" i]:upward(ytd-item-section-renderer)
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="#shorts" i]:upward(ytd-item-section-renderer)
 ---
 
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this. With this filter, you can remove videos with a given word in their title.

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -8,12 +8,12 @@ tags:
   - youtube
 template: |
   {{#each keywords}}
-  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="{{ . }}" i])
-  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="{{ . }}" i])
-  www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="{{ . }}" i])
-  www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="{{ . }}" i])
+  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="{{ . }}" i])
+  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="{{ . }}" i])
+  www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="{{ . }}" i])
+  www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="{{ . }}" i])
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
-  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="{{ . }}" i]:upward(ytd-item-section-renderer)
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="{{ . }}" i]:upward(ytd-item-section-renderer)
   {{/each}}
 tests:
   - params: {}
@@ -21,16 +21,16 @@ tests:
   - params:
       keywords: [ "lofi", "#shorts" ]
     output: |
-      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="lofi" i])
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="lofi" i])
-      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="lofi" i])
-      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="lofi" i])
-      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="lofi" i]:upward(ytd-item-section-renderer)
-      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title~="#shorts" i])
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title~="#shorts" i])
-      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title~="#shorts" i])
-      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title~="#shorts" i])
-      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title~="#shorts" i]:upward(ytd-item-section-renderer)
+      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="lofi" i])
+      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="lofi" i])
+      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="lofi" i])
+      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="lofi" i])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="lofi" i]:upward(ytd-item-section-renderer)
+      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="#shorts" i])
+      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="#shorts" i])
+      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="#shorts" i])
+      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="#shorts" i])
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*~="#shorts" i]:upward(ytd-item-section-renderer)
 ---
 
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this. With this filter, you can remove videos with a given word in their title.

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -8,12 +8,12 @@ tags:
   - youtube
 template: |
   {{#each keywords}}
-  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="{{ . }}" i])
-  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="{{ . }}" i])
-  www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="{{ . }}" i])
-  www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="{{ . }}" i])
+  www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title]:has-text(/\b{{this}}\b/i))
+  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title]:has-text(/\b{{this}}\b/i))
+  www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title]:has-text(/\b{{this}}\b/i))
+  www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title]:has-text(/\b{{this}}\b/i))
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
-  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="{{ . }}" i]:upward(ytd-item-section-renderer)
+  www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b{{this}}\b/i):upward(ytd-item-section-renderer)
   {{/each}}
 tests:
   - params: {}
@@ -21,16 +21,16 @@ tests:
   - params:
       keywords: [ "lofi", "#shorts" ]
     output: |
-      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="lofi" i])
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="lofi" i])
-      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="lofi" i])
-      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="lofi" i])
-      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="lofi" i]:upward(ytd-item-section-renderer)
-      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title*="#shorts" i])
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title*="#shorts" i])
-      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title*="#shorts" i])
-      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title*="#shorts" i])
-      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title*="#shorts" i]:upward(ytd-item-section-renderer)
+      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title]:has-text(/\blofi\b/i))
+      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title]:has-text(/\blofi\b/i))
+      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title]:has-text(/\blofi\b/i))
+      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title]:has-text(/\blofi\b/i))
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\blofi\b/i):upward(ytd-item-section-renderer)
+      www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))
+      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title]:has-text(/\b#shorts\b/i))
+      www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))
+      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))
+      www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b#shorts\b/i):upward(ytd-item-section-renderer)
 ---
 
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this. With this filter, you can remove videos with a given word in their title.


### PR DESCRIPTION
See https://github.com/letsblockit/letsblockit/issues/347 (Hide Youtube videos by title should look for other separators if possible)

I changed every `~` for `*`.