### PR TITLE
server: expire cached prefs after 30 minutes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
           run-tests = [ pinnedGo golangci-lint ];
           update-assets = [ nodejs-slim-18_x nodePackages.npm ];
           update-codegen = [ mockgen self.packages.${system}.sqlc ];
-          update-vendorsha = [ nix-prefetch ];
+          update-vendorsha = [ nix-prefetch gnused ];
           upgrade-deps = [ nodejs-slim-18_x nodePackages.npm pinnedGo nix-prefetch git ];
         };
       in

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/imantung/mario v0.9.1-0.20211124221804-dc993f6091b9
 	github.com/jackc/pgconn v1.14.0
 	github.com/jackc/pgtype v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/nix/letsblockit.nix
+++ b/nix/letsblockit.nix
@@ -4,6 +4,6 @@ buildGoModule.override { go = go_1_19; } {
   pname = "letsblockit";
   src = ./..;
   subPackages = "cmd/" + cmd;
-  vendorSha256 = "sha256-sd3dCf9TaDFyznHBphTLU6jU2DkQOOCLorynxCwQhy0=";
+  vendorSha256 = "sha256-FgkaFgDf6mQm9PE7Tm3ciZb8dz9CaHirIbHUqETlQFY=";
   version = "1.0";
 }

--- a/src/users/prefs.go
+++ b/src/users/prefs.go
@@ -3,26 +3,20 @@ package users
 import (
 	"context"
 	"time"
+	"zgo.at/zcache/v2"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/labstack/echo/v4"
 	"github.com/letsblockit/letsblockit/src/db"
 )
 
-const prefCacheSize = 2048
-
 type PreferenceManager struct {
-	cache *lru.Cache
+	cache *zcache.Cache[string, *db.UserPreference]
 	store db.Store
 }
 
 func NewPreferenceManager(store db.Store) (*PreferenceManager, error) {
-	cache, err := lru.New(prefCacheSize)
-	if err != nil {
-		return nil, err
-	}
 	return &PreferenceManager{
-		cache: cache,
+		cache: zcache.New[string, *db.UserPreference](30*time.Minute, 10*time.Minute),
 		store: store,
 	}, nil
 }
@@ -30,9 +24,7 @@ func NewPreferenceManager(store db.Store) (*PreferenceManager, error) {
 // Get retrieves the preferences from cache or DB. If no prefs are in DB, create a row with default values.
 func (m *PreferenceManager) Get(c echo.Context, user string) (*db.UserPreference, error) {
 	if entry, ok := m.cache.Get(user); ok {
-		if prefs, ok := entry.(*db.UserPreference); ok {
-			return prefs, nil
-		}
+		return entry, nil
 	}
 	var prefs db.UserPreference
 	if err := m.store.RunTx(c, func(ctx context.Context, q db.Querier) error {
@@ -45,7 +37,7 @@ func (m *PreferenceManager) Get(c echo.Context, user string) (*db.UserPreference
 	}); err != nil {
 		return nil, err
 	}
-	m.cache.Add(user, &prefs)
+	m.cache.Set(user, &prefs)
 	return &prefs, nil
 }
 
@@ -57,6 +49,6 @@ func (m *PreferenceManager) UpdateNewsCursor(c echo.Context, user string, at tim
 		UserID:     user,
 		NewsCursor: at,
 	})
-	m.cache.Remove(user)
+	m.cache.Delete(user)
 	return err
 }

--- a/src/users/prefs.go
+++ b/src/users/prefs.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"time"
+
 	"zgo.at/zcache/v2"
 
 	"github.com/labstack/echo/v4"


### PR DESCRIPTION
We are experimenting with running two VMs for the official instance (Europe & US West coast), while users should be directed to only the closest instance, they might fallback to the other one during rollouts. 

Make sure the instance does not keep outdated user prefs indefinitely. Let's start with a 30 minutes expiration duration, and iterate from there.