### PR TITLE
server: allow operator to set custom refresh period per list

### DIFF
--- a/src/db/interface.go
+++ b/src/db/interface.go
@@ -31,6 +31,7 @@ type Querier interface {
 	MarkListDownloaded(ctx context.Context, token uuid.UUID) error
 	RotateListToken(ctx context.Context, arg RotateListTokenParams) error
 	UpdateInstance(ctx context.Context, arg UpdateInstanceParams) error
+	UpdateListRefreshPeriod(ctx context.Context, arg UpdateListRefreshPeriodParams) error
 	UpdateNewsCursor(ctx context.Context, arg UpdateNewsCursorParams) error
 }
 

--- a/src/db/migrations/0009_list_refresh_period.up.sql
+++ b/src/db/migrations/0009_list_refresh_period.up.sql
@@ -1,0 +1,2 @@
+-- Allows instance operator to deviate from the default refresh period on lists with high traffic
+ALTER TABLE filter_lists ADD COLUMN refresh_period_hours INT NULL;

--- a/src/db/models.go
+++ b/src/db/models.go
@@ -33,11 +33,12 @@ type FilterInstance struct {
 }
 
 type FilterList struct {
-	ID           int32
-	UserID       string
-	Token        uuid.UUID
-	CreatedAt    time.Time
-	DownloadedAt sql.NullTime
+	ID                 int32
+	UserID             string
+	Token              uuid.UUID
+	CreatedAt          time.Time
+	DownloadedAt       sql.NullTime
+	RefreshPeriodHours sql.NullInt32
 }
 
 type UserPreference struct {

--- a/src/db/queries/qLists.sql
+++ b/src/db/queries/qLists.sql
@@ -24,7 +24,7 @@ WHERE user_id = $1
   AND token = $2;
 
 -- name: GetListForToken :one
-SELECT id, user_id, downloaded_at
+SELECT id, user_id, downloaded_at, refresh_period_hours
 FROM filter_lists
 WHERE token = $1
 LIMIT 1;
@@ -33,3 +33,9 @@ LIMIT 1;
 UPDATE filter_lists
 SET downloaded_at = NOW()
 WHERE token = $1;
+
+-- name: UpdateListRefreshPeriod :exec
+UPDATE filter_lists
+SET refresh_period_hours = $2
+WHERE token = $1;
+

--- a/src/filters/list.go
+++ b/src/filters/list.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	listHeaderTemplate = `! Title: letsblock.it - %s
-! Expires: 12 hours
+! Expires: %d hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/letsblockit/letsblockit/blob/main/LICENSE.txt
 `
@@ -28,6 +28,7 @@ type List struct {
 	Title     string      `yaml:"title" validate:"required"`
 	Instances []*Instance `yaml:"instances" validate:"dive,required"`
 	TestMode  bool        `yaml:"test_mode,omitempty"`
+	Expires   int         `yaml:"-"`
 }
 
 type repository interface {
@@ -44,7 +45,11 @@ func (i *Instance) Render(out io.Writer, repo repository) error {
 }
 
 func (l *List) Render(out io.Writer, logger logger, repo repository) error {
-	_, err := fmt.Fprintf(out, listHeaderTemplate, l.Title)
+	if l.Expires < 12 {
+		l.Expires = 12 // Minimal (and default) value of 12 hours
+	}
+
+	_, err := fmt.Fprintf(out, listHeaderTemplate, l.Title, l.Expires)
 	if err != nil {
 		return err
 	}

--- a/src/filters/list_test.go
+++ b/src/filters/list_test.go
@@ -46,6 +46,19 @@ func (s *ListTestSuite) TestRenderEmpty() {
 `, buf.String())
 }
 
+func (s *ListTestSuite) TestRenderSlowRefresh() {
+	buf := &strings.Builder{}
+	list := &List{
+		Expires: 40,
+	}
+	s.NoError(list.Render(buf, s.logger, s.repository))
+	s.Equal(`! Title: letsblock.it - 
+! Expires: 40 hours
+! Homepage: https://letsblock.it
+! License: https://github.com/letsblockit/letsblockit/blob/main/LICENSE.txt
+`, buf.String())
+}
+
 func (s *ListTestSuite) TestRenderOK() {
 	var list List
 	require.NoError(s.T(), yaml.Unmarshal(testList, &list))


### PR DESCRIPTION
Some lists are used on dozens of devices, and refreshing them every day creates undue load on the system.

Allow instance operators to set a separate fresh period for some lists. If set, a ±10% jitter is applied to the duration, to spread load if a lot devices use it.