### PR TITLE
youtube-shorts: update for new navbar icon

### DIFF
--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -3,8 +3,8 @@ tags:
   - youtube
 template: |
   {{! Navigation links }}
-  www.youtube.com##ytd-guide-renderer a.yt-simple-endpoint path[d^="M10 14.65v-5.3L15 12l-5 2.65zm7.77-4.33c-.77-.32-1.2-.5-1.2-.5L18"]:upward(ytd-guide-entry-renderer)
-  www.youtube.com##ytd-mini-guide-renderer a.yt-simple-endpoint path[d^="M10 14.65v-5.3L15 12l-5 2.65zm7.77-4.33c-.77-.32-1.2-.5-1.2-.5L18"]:upward(ytd-mini-guide-entry-renderer)
+  www.youtube.com##ytd-guide-renderer a.yt-simple-endpoint path[d^="M10 14.65v-5.3L15 12l-5 2.65zm7.77-4.33"]:upward(ytd-guide-entry-renderer)
+  www.youtube.com##ytd-mini-guide-renderer a.yt-simple-endpoint path[d^="M10 14.65v-5.3L15 12l-5 2.65zm7.77-4.33"]:upward(ytd-mini-guide-entry-renderer)
   {{! Homepage shelf }}
   www.youtube.com##ytd-browse #dismissible ytd-rich-grid-slim-media[is-short]:upward(ytd-rich-section-renderer)
   {{! New style with logo, desktop }}


### PR DESCRIPTION
I reverted https://github.com/letsblockit/letsblockit/pull/376 because the new icon is not fully rolled-out yet, but I see it again now.

Instead of two rules for old & new icon, I'm shortening the existing svg matching to match both icons. Quick test didn't surface false-positive for that updated rule.