### PR TITLE
youtube-cleanup: update for new hashtag design

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -40,6 +40,7 @@ template: |
   www.youtube.com##ytd-shorts .disclaimer-container:upward(#info-panel)
   {{/if}}
   {{#if remove-video-hashtags}}
+  www.youtube.com###description #info a[href^="/hashtag/"]
   www.youtube.com###super-title
   www.youtube.com##.super-title
   {{/if}}
@@ -69,6 +70,7 @@ tests:
   - params:
       remove-video-hashtags: true
     output: |
+      www.youtube.com###description #info a[href^="/hashtag/"]
       www.youtube.com###super-title
       www.youtube.com##.super-title
   - params:


### PR DESCRIPTION
The existing rules don't work with the new youtube layout (not another new one, but the current new one). *Some how never tested this rule before after the change.* 

If you play a video with hashtags - like `https://www.youtube.com/watch?v=llxmTHt5zPs (guitar music)` the hashtags are not shown above the video title, but at the end of the line which shows the date the video got uploaded. 

See:
![afbeelding](https://user-images.githubusercontent.com/81161435/232073441-232b7bd9-2a0f-423f-b029-624415153f5f.png)
