### PR TITLE
google-search-cleanup: update to match the new "From sources across the web" content

### DIFF
--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -37,7 +37,7 @@ tags:
 template: |
   {{#if rich-results}}
   {{! Toplevel rich content above columns }}
-  www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+  www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel,g-img)
   {{! Rich content in normal pages }}
   www.google.*###rso:has(> div:nth-of-type(6)) > div:has(g-more-link,g-section-with-header)
   {{! "Find results on" carousel }}
@@ -82,7 +82,7 @@ tests:
   - params:
       rich-results: true
     output: |
-      www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel)
+      www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel,g-img)
       www.google.*###rso:has(> div:nth-of-type(6)) > div:has(g-more-link,g-section-with-header)
       www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div[role="heading"]+g-scrolling-carousel)
       www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)


### PR DESCRIPTION
Example search for "b2b product metrics":

<img width="1161" alt="image" src="https://github.com/letsblockit/letsblockit/assets/6241083/58824ef7-b1bc-45b3-9617-8b216c1895d3">

The only non-minified stuff I could find in this spaghetti code is the `g-img` element type for the images, that appears in other types of "rich content". Let's match this one and hope we don't create false-positives somewhere else.