### PR TITLE
youtube-cleanup: Remove channel info at bottom of video description

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -22,6 +22,9 @@ params:
     description: Hide the copyright notice in the video description
     type: checkbox
     default: false
+  - name: remove-channel-info
+    description: Removes channel information below the video description
+    default: false
   - name: remove-stream-chat
     description: Hide the live chat when viewing streams
     type: checkbox
@@ -69,6 +72,9 @@ template: |
   {{#if remove-copyright-notice}}
   www.youtube.com###description .ytd-watch-metadata #items:has(.ytd-video-description-music-section-renderer)
   m.youtube.com##ytm-video-description-music-section-renderer
+  {{/if}}
+  {{#if remove-channel-info}}
+  www.youtube.com###structured-description ytd-video-description-infocards-section-renderer
   {{/if}}
   {{#if remove-stream-chat}}
   www.youtube.com###chat:remove()
@@ -118,6 +124,10 @@ tests:
     output: |
       www.youtube.com###description .ytd-watch-metadata #items:has(.ytd-video-description-music-section-renderer)
       m.youtube.com##ytm-video-description-music-section-renderer
+  - params:
+      remove-channel-info: true
+    output: |
+      www.youtube.com###structured-description ytd-video-description-infocards-section-renderer
   - params:
       remove-stream-chat: true
     output: |

--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -24,6 +24,7 @@ params:
     default: false
   - name: remove-channel-info
     description: Removes channel information below the video description
+    type: checkbox
     default: false
   - name: remove-stream-chat
     description: Hide the live chat when viewing streams


### PR DESCRIPTION
As per new lay-out YouTube shows additional channel info at the bottom of the video description (example: `https://www.youtube.com/watch?v=UuUVAZHV1qU`).

![afbeelding](https://github.com/letsblockit/letsblockit/assets/81161435/445d533a-02d9-47ad-9954-3c0ebcf43faa)
