### PR TITLE
youtube: fix gaps in video grids with new layout

### DIFF
--- a/data/filters/templates/youtube-channel.yaml
+++ b/data/filters/templates/youtube-channel.yaml
@@ -1,5 +1,6 @@
 title: "YouTube: filter out videos by channel"
 contributors:
+  - BPower0036
   - JohnyP36
   - xvello
 params:
@@ -17,6 +18,8 @@ template: |
   m.youtube.com##ytm-browse ytm-rich-item-renderer:has(a[href$="{{ . }}"])
   m.youtube.com##ytm-search ytm-video-with-context-renderer:has(a[href$="{{ . }}"])
   m.youtube.com##ytm-search ytm-compact-channel-renderer:has(a[href$="{{ . }}"])
+  {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   {{/each}}
 tests:
   - params: {}
@@ -30,6 +33,7 @@ tests:
       m.youtube.com##ytm-browse ytm-rich-item-renderer:has(a[href$="ChannelURL"])
       m.youtube.com##ytm-search ytm-video-with-context-renderer:has(a[href$="ChannelURL"])
       m.youtube.com##ytm-search ytm-compact-channel-renderer:has(a[href$="ChannelURL"])
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 ---
 
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this.

--- a/data/filters/templates/youtube-channel.yaml
+++ b/data/filters/templates/youtube-channel.yaml
@@ -21,7 +21,8 @@ template: |
   youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 tests:
   - params: {}
-    output: ""
+    output: |
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   - params:
       channels: [ "ChannelURL" ]
     output: |

--- a/data/filters/templates/youtube-mixes.yaml
+++ b/data/filters/templates/youtube-mixes.yaml
@@ -11,6 +11,8 @@ template: |
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
   www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
   m.youtube.com##ytm-search ytm-compact-radio-renderer
+  {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }}
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 tests:
   - params: {}
     output: |
@@ -19,6 +21,7 @@ tests:
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
       www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
       m.youtube.com##ytm-search ytm-compact-radio-renderer
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 ---
 
 This template removes the mixes / radios showing up in search results and recommendations.

--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -41,6 +41,8 @@ template: |
   m.youtube.com##ytm-search ytm-thumbnail-overlay-time-status-renderer[data-style="SHORTS"]:upward(ytm-compact-video-renderer)
   {{! Mobile sidebar suggestions }}
   m.youtube.com##ytm-single-column-watch-next-results-renderer ytm-thumbnail-overlay-time-status-renderer span:has-text(/^(0:\d\d|1:0\d)$/):upward(ytm-video-with-context-renderer)
+  {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 ---
 
 Youtube shorts are more and more prevalent, and I don't care one bit about that format. This filter hides most

--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -15,6 +15,7 @@ template: |
   {{! New style with logo, desktop }}
   www.youtube.com##ytd-browse[page-subtype="home"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-rich-item-renderer)
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-grid-video-renderer,ytd-rich-item-renderer)
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   www.youtube.com##ytd-search .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Suggestions, old layout }}
   www.youtube.com##ytd-watch-next-secondary-results-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-compact-video-renderer,ytd-shelf-renderer)

--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -15,7 +15,6 @@ template: |
   {{! New style with logo, desktop }}
   www.youtube.com##ytd-browse[page-subtype="home"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-rich-item-renderer)
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-grid-video-renderer,ytd-rich-item-renderer)
-  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   www.youtube.com##ytd-search .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Suggestions, old layout }}
   www.youtube.com##ytd-watch-next-secondary-results-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-compact-video-renderer,ytd-shelf-renderer)

--- a/data/filters/templates/youtube-upcoming-videos.yaml
+++ b/data/filters/templates/youtube-upcoming-videos.yaml
@@ -1,5 +1,6 @@
 title: "YouTube: filter out upcoming videos and streams"
 contributors:
+  - BPower0036
   - xvello
 tags:
   - youtube
@@ -8,12 +9,15 @@ template: |
   www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]:upward(ytd-item-section-renderer)
+  {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 tests:
   - params: {}
     output: |
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])
       www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]:upward(ytd-item-section-renderer)
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 ---
 
 Youtube gives enhanced visiblity to live streams, and many channels are abusing this by releasing regular videos as streams.

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -1,5 +1,6 @@
 title: "YouTube: filter out videos by title"
 contributors:
+  - BPower0036
   - JohnyP36
   - xvello
 params:
@@ -21,6 +22,8 @@ template: |
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b{{this}}\b/i):upward(ytd-item-section-renderer)
   m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b{{this}}\b/i))
+  {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
+  youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   {{/each}}
 tests:
   - params: {}
@@ -46,6 +49,7 @@ tests:
       m.youtube.com##.watch-below-the-player ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b#shorts\b/i))
       www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b#shorts\b/i):upward(ytd-item-section-renderer)
       m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b#shorts\b/i))
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 ---
 
 Not everything on the platform matches your interests, and the famous algorithm is not that great at understanding this. With this filter, you can remove videos with a given word in their title.

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -22,9 +22,9 @@ template: |
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b{{this}}\b/i):upward(ytd-item-section-renderer)
   m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b{{this}}\b/i))
+  {{/each}}
   {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
   youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
-  {{/each}}
 tests:
   - params: {}
     output: ""
@@ -40,7 +40,6 @@ tests:
       m.youtube.com##.watch-below-the-player ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\blofi\b/i))
       www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\blofi\b/i):upward(ytd-item-section-renderer)
       m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\blofi\b/i))
-      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title]:has-text(/\b#shorts\b/i))
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -22,9 +22,9 @@ template: |
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b{{this}}\b/i):upward(ytd-item-section-renderer)
   m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b{{this}}\b/i))
-  {{/each}}
   {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
   youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
+  {{/each}}
 tests:
   - params: {}
     output: ""
@@ -40,6 +40,7 @@ tests:
       m.youtube.com##.watch-below-the-player ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\blofi\b/i))
       www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\blofi\b/i):upward(ytd-item-section-renderer)
       m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\blofi\b/i))
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
       www.youtube.com##ytd-browse ytd-grid-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))
       www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[title]:has-text(/\b#shorts\b/i))
       www.youtube.com##ytd-search ytd-video-renderer:has(#video-title[title]:has-text(/\b#shorts\b/i))

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -22,9 +22,9 @@ template: |
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer #video-title[title]:has-text(/\b{{this}}\b/i):upward(ytd-item-section-renderer)
   m.youtube.com##ytm-browse div[tab-identifier="FEsubscriptions"] ytm-video-with-context-renderer:has(.media-item-headline:has-text(/\b{{this}}\b/i))
+  {{/each}}
   {{! Match the ytd-rich-grid-row element and its #contents child, to disable their CSS boxing }} 
   youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
-  {{/each}}
 tests:
   - params: {}
     output: ""

--- a/data/filters/templates/youtube-video-title.yaml
+++ b/data/filters/templates/youtube-video-title.yaml
@@ -27,7 +27,8 @@ template: |
   youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
 tests:
   - params: {}
-    output: ""
+    output: |
+      youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:contents !important;)
   - params:
       keywords: [ "lofi", "#shorts" ]
     output: |


### PR DESCRIPTION
The new youtube layout added `ytd-rich-grid-row` elements wrapping the thumbnails. These elements block the reflow when we hide thumbnails, creating gaps in the grid.

This rule uses add the `display: contents` CSS property, that's basically "ignore these elements when computing layout, effectively returning the DOM to a reflowing list of thumbnails.

For ease of use, we're adding this rule to every template that hides thumbnails in the homepage or subscriptions page. Content blockers will transparently de-duplicate that rule when parsing the list. 