### PR TITLE
youtube-search-cleanup: fix the rules to actually hide elements

### DIFF
--- a/data/filters/templates/youtube-search-cleanup.yaml
+++ b/data/filters/templates/youtube-search-cleanup.yaml
@@ -9,7 +9,7 @@ template: |
   www.youtube.com##ytd-search ytd-item-section-renderer ytd-shelf-renderer:style(border: 2px dashed red !important)
   {{! Related searches }}
   www.youtube.com##ytd-search ytd-item-section-renderer ytd-horizontal-card-list-renderer:style(border: 2px dashed red !important)
-  m.youtube.com##ytm-badge-and-byline-renderer + ytm-badge-and-byline-renderer:upward(ytm-video-with-context-renderer):style(border: 2px dashed red !important)
+  m.youtube.com##ytm-search ytm-badge-and-byline-renderer + ytm-badge-and-byline-renderer:not(:has(span + span)):not(:has-text(4K)):upward(ytm-video-with-context-renderer):style(border: 2px dashed red !important)
 ---
 
 These rules remove related searches and related results from the YouTube search results, only leaving organic

--- a/data/filters/templates/youtube-search-cleanup.yaml
+++ b/data/filters/templates/youtube-search-cleanup.yaml
@@ -6,10 +6,9 @@ tags:
   - youtube
 template: |
   {{! Non organic results such as For You, Previously Watched, People Also Watched... }}
-  www.youtube.com##ytd-search ytd-item-section-renderer ytd-shelf-renderer:style(border: 2px dashed red !important)
+  www.youtube.com##ytd-search ytd-item-section-renderer ytd-shelf-renderer
   {{! Related searches }}
-  www.youtube.com##ytd-search ytd-item-section-renderer ytd-horizontal-card-list-renderer:style(border: 2px dashed red !important)
-  m.youtube.com##ytm-search ytm-badge-and-byline-renderer + ytm-badge-and-byline-renderer:not(:has(span + span)):not(:has-text(4K)):upward(ytm-video-with-context-renderer):style(border: 2px dashed red !important)
+  www.youtube.com##ytd-search ytd-item-section-renderer ytd-horizontal-card-list-renderer
 ---
 
 These rules remove related searches and related results from the YouTube search results, only leaving organic

--- a/data/filters/templates/youtube-search-cleanup.yaml
+++ b/data/filters/templates/youtube-search-cleanup.yaml
@@ -1,5 +1,6 @@
 title: "YouTube: search interface cleanups"
 contributors:
+  - JohnyP36
   - xvello
 tags:
   - youtube
@@ -8,6 +9,7 @@ template: |
   www.youtube.com##ytd-search ytd-item-section-renderer ytd-shelf-renderer:style(border: 2px dashed red !important)
   {{! Related searches }}
   www.youtube.com##ytd-search ytd-item-section-renderer ytd-horizontal-card-list-renderer:style(border: 2px dashed red !important)
+  m.youtube.com##ytm-badge-and-byline-renderer + ytm-badge-and-byline-renderer:upward(ytm-video-with-context-renderer):style(border: 2px dashed red !important)
 ---
 
 These rules remove related searches and related results from the YouTube search results, only leaving organic


### PR DESCRIPTION
Added support for mobile website
Example url: `https://m.youtube.com/results?search_query=shuffle+dance+music+`

The blocked elements are per video and it's not one block with videos. 
The rule I made, is based on the fact that below the channel name is an extra badge (this is different in every language, so mine is Dutch and says  "Gerelateerd" *(Related)*)

Don't know actually why you put a red border around the elements...

PrintScreen
![afbeelding](https://github.com/letsblockit/letsblockit/assets/81161435/08ea99e5-3d7c-4ab9-b57f-47011e3d8110)
