### PR TITLE
youtube-mixes: improve rule performance

### DIFF
--- a/data/filters/templates/youtube-mixes.yaml
+++ b/data/filters/templates/youtube-mixes.yaml
@@ -1,17 +1,18 @@
 title: "YouTube: filter out mixes and radios"
 contributors:
+  - BPower0036
   - xvello
 tags:
   - youtube
 template: |
-  www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[href*="&start_radio=1"])
+  www.youtube.com##ytd-browse #video-title-link[href*="&start_radio=1"]:upward(ytd-rich-item-renderer)
   www.youtube.com##ytd-search ytd-radio-renderer
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
   www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
 tests:
   - params: {}
     output: |
-      www.youtube.com##ytd-browse ytd-rich-item-renderer:has(#video-title-link[href*="&start_radio=1"])
+      www.youtube.com##ytd-browse #video-title-link[href*="&start_radio=1"]:upward(ytd-rich-item-renderer)
       www.youtube.com##ytd-search ytd-radio-renderer
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
       www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]


### PR DESCRIPTION
Since you stated in https://github.com/letsblockit/letsblockit/pull/454#issue-1750061231
> Move away from the `:has(` operator and into the `:upward(` one for better performance + match both container classes

And this template had still `:has(` operators, I changed them into `:upward`