### PR TITLE
youtube-mixes: Add support for mobile YouTube

### DIFF
--- a/data/filters/templates/youtube-mixes.yaml
+++ b/data/filters/templates/youtube-mixes.yaml
@@ -1,5 +1,6 @@
 title: "YouTube: filter out mixes and radios"
 contributors:
+  - JohnyP36
   - xvello
 tags:
   - youtube
@@ -8,6 +9,7 @@ template: |
   www.youtube.com##ytd-search ytd-radio-renderer
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
   www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
+  m.youtube.com##ytm-search ytm-compact-radio-renderer
 tests:
   - params: {}
     output: |
@@ -15,6 +17,7 @@ tests:
       www.youtube.com##ytd-search ytd-radio-renderer
       www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
       www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
+      m.youtube.com##ytm-search ytm-compact-radio-renderer
 ---
 
 This template removes the mixes / radios showing up in search results and recommendations.


### PR DESCRIPTION
I could only find radio/mixes if I searched something. 
Regarding the other rule: I could not find radios/mixes on those places in `m.youtube.com`.