### PR TITLE
youtube-mixes: add support for mobile youtube (homepage)

### DIFF
--- a/data/filters/templates/youtube-mixes.yaml
+++ b/data/filters/templates/youtube-mixes.yaml
@@ -10,15 +10,9 @@ template: |
   www.youtube.com##ytd-search ytd-radio-renderer
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
   www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
+  m.youtube.com##ytm-browse ytm-radio-renderer:upward(ytm-rich-item-renderer)
   m.youtube.com##ytm-search ytm-compact-radio-renderer
-tests:
-  - params: {}
-    output: |
-      www.youtube.com##ytd-browse #video-title-link[href*="&start_radio=1"]:upward(ytd-rich-item-renderer)
-      www.youtube.com##ytd-search ytd-radio-renderer
-      www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-compact-radio-renderer
-      www.youtube.com##ytd-player div.videowall-endscreen a[data-is-list=true]
-      m.youtube.com##ytm-search ytm-compact-radio-renderer
+
 ---
 
 This template removes the mixes / radios showing up in search results and recommendations.


### PR DESCRIPTION
- Add a rule for mixes on the homepage. Just removing the `ytm-radio-renderer` does not allow other videos to reflow, so I'm matching the parent `ytm-rich-item-renderer`
- Remove the tests section as we don't have params

![Screenshot_20230610_190351](https://github.com/letsblockit/letsblockit/assets/6241083/6e212a8a-ff1d-4f57-8ab1-48e9ac8acccd)
