### PR TITLE
search-results: remove Bing support and link to uBlacklist project

### DIFF
--- a/data/filters/templates/search-results.yaml
+++ b/data/filters/templates/search-results.yaml
@@ -6,10 +6,6 @@ contributors:
 sponsors:
   - Webswonder
 params:
-  - name: bing
-    description: Generate rules for Bing
-    type: checkbox
-    default: false
   - name: duckduckgo
     description: Generate rules for DuckDuckGo
     type: checkbox
@@ -75,7 +71,6 @@ params:
         source: https://github.com/quenhus/uBlock-Origin-dev-filter/blob/main/data/wikipedia_copycats.txt
         license: https://github.com/quenhus/uBlock-Origin-dev-filter/blob/main/LICENSE
 tags:
-  - bing
   - duckduckgo
   - google
   - kagi
@@ -84,9 +79,6 @@ tags:
   - brave
 template: |
   {{#each sites as |site siteId|}}
-  {{#if ../bing}}
-  bing.com###b_content a[href*="{{site}}"]:upward(li)
-  {{/if}}
   {{#if ../google}}
   www.google.*##.g:has(a[href*="{{site}}"])
   www.google.*##a[href*="{{site}}"]:upward(1)
@@ -126,7 +118,6 @@ template: |
   {{/each}}
 tests:
   - params:
-      bing: true
       brave: true
       duckduckgo: true
       google: true
@@ -137,7 +128,6 @@ tests:
         - snapcraft.io/install
       startpage: true
     output: |
-      bing.com###b_content a[href*=".pinterest."]:upward(li)
       www.google.*##.g:has(a[href*=".pinterest."])
       www.google.*##a[href*=".pinterest."]:upward(1)
       duckduckgo.com##a[data-testid="result-title-a"][href*=".pinterest."]:upward(.nrn-react-div)
@@ -147,7 +137,6 @@ tests:
       search.brave.com###results a[href*=".pinterest."]:upward(.snippet)
       search.brave.com###img-results a[href*=".pinterest."]:upward([id^="img"])
       search.brave.com###results a[href*=".pinterest."]:upward(.card)
-      bing.com###b_content a[href*="snapcraft.io/install"]:upward(li)
       www.google.*##.g:has(a[href*="snapcraft.io/install"])
       www.google.*##a[href*="snapcraft.io/install"]:upward(1)
       duckduckgo.com##a[data-testid="result-title-a"][href*="snapcraft.io/install"]:upward(.nrn-react-div)
@@ -212,3 +201,9 @@ Results will be hidden if their link destination contains one of the values you 
 The [uBlock-Origin-dev-filter](https://github.com/quenhus/uBlock-Origin-dev-filter) project maintains a list
 if copycat websites for Github and Stackoverflow. You can use their list by ticking the boxes at the bottom
 of the form. Rules to block these websites will be added at the bottom of the filter.
+
+<div role="alert" class="alert alert-secondary bg-secondary-subtle">
+Due to technical limitations, this template has lower performance and compatibility than dedicated
+extensions such as <a href="https://iorate.github.io/ublacklist/docs">uBlacklist</a>.
+We suggest testing this extension if you need compatibility with search engines we don't support, such as Bing.
+</div>


### PR DESCRIPTION
Closes https://github.com/letsblockit/letsblockit/issues/430, check that issue for context.

The Bing rules have been broken for at least two months, due to them adding obfuscation. For these users, my recommendation is to use the dedicated uBlacklist extension instead, as that extension can run javascript to decode the URL, and amortize its filtering cost more easily than we can with uBO rules.

I think there's still room for that template as a "don't install yet another extension" territory for a few hundred domains, but power users will be better served by that dedicated extension.