### PR TITLE
youtube-cleanup: update for new layout

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -66,6 +66,7 @@ template: |
   m.youtube.com##ytm-video-description-header-renderer button-view-model a[href^="/hashtag/"]
   {{/if}}
   {{#if remove-text-after-buttons-below-video}}
+  www.youtube.com###actions.ytd-watch-metadata button > div[class$="text-content"]:not(:has-text(/[\d]/))
   www.youtube.com###actions.ytd-watch-metadata ytd-button-renderer .yt-spec-button-shape-next .yt-spec-button-shape-next--button-text-content
   www.youtube.com###actions.ytd-watch-metadata ytd-button-renderer .yt-spec-button-shape-next__icon:style(margin-right: -6px !important; margin-left: -6px !important;)
   m.youtube.com##ytm-slim-video-action-bar-renderer button [class*="button-text-content"]:not(:has-text(/\d/))
@@ -119,6 +120,7 @@ tests:
   - params:
       remove-text-after-buttons-below-video: true
     output: |
+      www.youtube.com###actions.ytd-watch-metadata button > div[class$="text-content"]:not(:has-text(/[\d]/))
       www.youtube.com###actions.ytd-watch-metadata ytd-button-renderer .yt-spec-button-shape-next .yt-spec-button-shape-next--button-text-content
       www.youtube.com###actions.ytd-watch-metadata ytd-button-renderer .yt-spec-button-shape-next__icon:style(margin-right: -6px !important; margin-left: -6px !important;)
       m.youtube.com##ytm-slim-video-action-bar-renderer button [class*="button-text-content"]:not(:has-text(/\d/))


### PR DESCRIPTION
Recently I am getting a new button layout for which the current rule don't work.
This fix solves the problem.

![afbeelding](https://github.com/letsblockit/letsblockit/assets/80090789/3b0f5eaf-08ae-4ae0-9004-6c19947f3157)
to
![afbeelding](https://github.com/letsblockit/letsblockit/assets/80090789/60cd9c3d-dc9f-45b8-aeea-3206cd23301c)

