### PR TITLE
youtube-cleanup: add option to hide the chapter timeline in the video description box

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -27,7 +27,7 @@ params:
     type: checkbox
     default: false
   - name: remove-chapters
-    description: Hides the chapters that are in a video from the video description box
+    description: Hide the chapter timeline in the video description box
     type: checkbox
     default: false
   - name: remove-stream-chat

--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -26,6 +26,9 @@ params:
     description: Removes channel information below the video description
     type: checkbox
     default: false
+  - name: remove-chapters
+    description: Hides the chapters that are in a video from the video description box
+    default: false
   - name: remove-stream-chat
     description: Hide the live chat when viewing streams
     type: checkbox
@@ -79,6 +82,10 @@ template: |
   {{#if remove-channel-info}}
   www.youtube.com###structured-description ytd-video-description-infocards-section-renderer
   m.youtube.com##.modern-sd-container ytm-video-description-infocards-section-renderer
+  {{/if}}
+  {{#if remove-chapters}}
+  www.youtube.com###structured-description ytd-horizontal-card-list-renderer.ytd-structured-description-content-renderer
+  m.youtube.com##.modern-sd-container ytm-horizontal-card-list-renderer
   {{/if}}
   {{#if remove-stream-chat}}
   www.youtube.com###chat:remove()
@@ -135,6 +142,11 @@ tests:
     output: |
       www.youtube.com###structured-description ytd-video-description-infocards-section-renderer
       m.youtube.com##.modern-sd-container ytm-video-description-infocards-section-renderer
+ - params:
+      remove-chapters: true
+    output: |
+      www.youtube.com###structured-description ytd-horizontal-card-list-renderer.ytd-structured-description-content-renderer
+      m.youtube.com##.modern-sd-container ytm-horizontal-card-list-renderer
   - params:
       remove-stream-chat: true
     output: |

--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -28,6 +28,7 @@ params:
     default: false
   - name: remove-chapters
     description: Hides the chapters that are in a video from the video description box
+    type: checkbox
     default: false
   - name: remove-stream-chat
     description: Hide the live chat when viewing streams

--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -142,7 +142,7 @@ tests:
     output: |
       www.youtube.com###structured-description ytd-video-description-infocards-section-renderer
       m.youtube.com##.modern-sd-container ytm-video-description-infocards-section-renderer
- - params:
+  - params:
       remove-chapters: true
     output: |
       www.youtube.com###structured-description ytd-horizontal-card-list-renderer.ytd-structured-description-content-renderer


### PR DESCRIPTION
See issue #479 for background info and printscreen. 

At the bottom of video descriptions there is sometimes a section called "chapters" *(name depends on language)* if the video has chapters. Some want this to be removed.