### PR TITLE
db: remove filter instances for twitter templates

### DIFF
--- a/src/db/migrations/0010_twitter_remove.sql
+++ b/src/db/migrations/0010_twitter_remove.sql
@@ -1,0 +1,6 @@
+--- The two twitter templates have been deprecated
+--- in the previous release, remove them from the DB
+
+DELETE
+FROM filter_instances
+WHERE template_name IN ('twitter-tweets-by-hashtag', 'twitter-tweets-by-user');


### PR DESCRIPTION
The two twitter templates have been deprecated in the previous release, remove them from the DB.

I intentionally didn't enable it in the previous release to allow self-hosted users to rollback without losing data.