### PR TITLE
google-search-cleanup: update "People also ask" rule

### DIFF
--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -49,7 +49,7 @@ template: |
   www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
-  www.google.com###rso div.related-question-pair:upward(div[jscontroller])
+  www.google.*###rso div.related-question-pair:upward(div[jscontroller])
   {{/if}}
   {{#if related-searches}}
   www.google.*###botstuff #bres
@@ -78,7 +78,7 @@ tests:
       related-questions: true
       related-searches: true
     output: |
-      www.google.com###rso div.related-question-pair:upward(div[jscontroller])
+      www.google.*###rso div.related-question-pair:upward(div[jscontroller])
       www.google.*###botstuff #bres
   - params:
       rich-results: true

--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -49,8 +49,7 @@ template: |
   www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   {{/if}}
   {{#if related-questions}}
-  www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div.related-question-pair)
-  www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
+  www.google.com###rso div.related-question-pair:upward(div[jscontroller])
   {{/if}}
   {{#if related-searches}}
   www.google.*###botstuff #bres
@@ -79,8 +78,7 @@ tests:
       related-questions: true
       related-searches: true
     output: |
-      www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div.related-question-pair)
-      www.google.*###kp-wp-tab-overview > div:has(div.related-question-pair)
+      www.google.com###rso div.related-question-pair:upward(div[jscontroller])
       www.google.*###botstuff #bres
   - params:
       rich-results: true


### PR DESCRIPTION
Fixes https://github.com/letsblockit/letsblockit/issues/500

Both the regular and the alternative `#kp-wp-tab-overview` layouts work with this rule. Tested on these pages:
  - https://www.google.com/search?q=time+in+uk (regular layout)
  - https://www.google.com/search?q=best+actor+2022 (alternative layout for cultural topics)
