### PR TITLE
youtube-cleanup: Add warning for `remove-channel-info` in video description

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -24,7 +24,9 @@ params:
     type: checkbox
     default: false
   - name: remove-channel-info
-    description: Removes channel information below the video description (Warning: in newer YT layouts enabling this rule may result in braking down the functionality of clicking on the information icon in the right-top corner of the video)
+    description: | 
+      Removes channel information below the video description 
+      Warning: in newer YT layouts enabling this rule may result in braking down the functionality of clicking on the information icon in the right-top corner of the video
     type: checkbox
     default: false
   - name: remove-chapters

--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -24,7 +24,7 @@ params:
     type: checkbox
     default: false
   - name: remove-channel-info
-    description: Removes channel information below the video description
+    description: Removes channel information below the video description (Warning: in newer YT layouts enabling this rule may result in braking down the functionality of clicking on the information icon in the right-top corner of the video)
     type: checkbox
     default: false
   - name: remove-chapters


### PR DESCRIPTION
See discussion #503 

Is this a possible solution or should we add this warning at the button of the template?