### PR TITLE
Hide Shorts from YouTube Subscriptions page

### DIFF
--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -3,6 +3,7 @@ contributors:
   - BPower0036
   - chedanix
   - kiriya-aoi
+  - JohnyP36
   - SiggyPony
   - xvello
 tags:

--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -5,6 +5,7 @@ contributors:
   - kiriya-aoi
   - SiggyPony
   - xvello
+  - vimode
 tags:
   - youtube
 template: |
@@ -23,6 +24,8 @@ template: |
   www.youtube.com##ytd-watch-next-secondary-results-renderer ytd-reel-shelf-renderer
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-item-section-renderer)
+  {{! Hides Shorts section on the Subscriptions page }}
+  www.youtube.com##ytd-rich-section-renderer.ytd-rich-grid-renderer.style-scope
   {{! Channels homepage }}
   www.youtube.com##ytd-browse[page-subtype="channels"] #contents.ytd-reel-shelf-renderer:upward(ytd-item-section-renderer)
   {{! Trending section }}

--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -5,7 +5,6 @@ contributors:
   - kiriya-aoi
   - SiggyPony
   - xvello
-  - vimode
 tags:
   - youtube
 template: |


### PR DESCRIPTION
Added a new filter to remove this newly added section of *Shorts* in between the subscription feed. 
I am not sure if its the new UI or just an experiment. 

Added screenshot(s) for clarity. 
![Before adding the filter](https://github.com/letsblockit/letsblockit/assets/39148877/c2246c90-54fb-448e-821f-9d21a03b0d83)

After adding the filter to my list of uBlock filters.
![After adding newfilter](https://github.com/letsblockit/letsblockit/assets/39148877/f1cef7ac-fc3d-4d78-9103-1a195434bce6)

Hope I updated the filter list properly and provided sufficient information for the PR. Let me know if any changes are required.

Thank you.