### PR TITLE
woolworths-cleanup: add new woolworths (AU) search results cleanup template

### DIFF
--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -28,7 +28,7 @@ tests:
   - params:
       market-partners: true
     output: |
-      www.woolworths.com.au###search-content ##[class*="market-product-message-wrapper"]
+      www.woolworths.com.au###search-content shared-product-vendor-message:upward(div.product-grid-v2--tile)
   - params:
       non-product-titles: true
     output: |

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -1,5 +1,6 @@
 title: "Woolworths (AU): Cleanup search results"
 contributors:
+  - JohnyP36
   - sammcj
   - xvello
 params:

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -8,7 +8,7 @@ params:
     description: Hide reseller items from market partners in search results
     type: checkbox
     default: true
-  - name: non-product-titles
+  - name: non-product-tiles
     description: Hide non-product tiles in search results
     type: checkbox
     default: true
@@ -19,7 +19,7 @@ template: |
   {{#if market-partners}}
   www.woolworths.com.au###search-content shared-product-vendor-message:upward(div.product-grid-v2--tile)
   {{/if}}
-  {{#if non-product-titles}}
+  {{#if non-product-tiles}}
   www.woolworths.com.au###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
   {{/if}}
 tests:
@@ -30,9 +30,9 @@ tests:
     output: |
       www.woolworths.com.au###search-content shared-product-vendor-message:upward(div.product-grid-v2--tile)
   - params:
-      non-product-titles: true
+      non-product-tiles: true
     output: |
       www.woolworths.com.au###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
 
 ---
-This filter template allows you to hide reseller ("market partner") items/ads and non-product titles from the Woolworths (AU) search results.
+This filter template allows you to hide reseller ("market partner") items/ads and non-product tiles from the Woolworths (AU) search results.

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -27,17 +27,11 @@ tests:
   - params:
       market-partners: true
     output: |
-      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ##[class*="market-product-message-wrapper"]
+      www.woolworths.com.au###search-content ##[class*="market-product-message-wrapper"]
   - params:
       non-product-titles: true
     output: |
-      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
-  - params:
-      market-partners: true
-      non-product-titles: true
-    output: |
-      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ##[class*="market-product-message-wrapper"]
-      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
+      www.woolworths.com.au###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
 
 ---
 This filter template allows you to hide reseller ("market partner") items/ads and non-product titles from the Woolworths (AU) search results.

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -1,0 +1,43 @@
+title: "Woolworths (AU): Cleanup search results"
+contributors:
+  - sammcj
+  - xvello
+params:
+  - name: market-partners
+    description: Hide reseller items from market partners in search results
+    type: checkbox
+    default: true
+  - name: non-product-titles
+    description: Hide non-product titles in search results
+    type: checkbox
+    default: true
+tags:
+  - woolworths
+  - australia
+template: |
+  {{#if market-partners}}
+  www.woolworths.com.au###search-content ##[class*="market-product-message-wrapper"]
+  {{/if}}
+  {{#if non-product-titles}}
+  www.woolworths.com.au###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
+  {{/if}}
+tests:
+  - params: {}
+    output: ""
+  - params:
+      market-partners: true
+    output: |
+      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ##[class*="market-product-message-wrapper"]
+  - params:
+      non-product-titles: true
+    output: |
+      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
+  - params:
+      market-partners: true
+      non-product-titles: true
+    output: |
+      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ##[class*="market-product-message-wrapper"]
+      www.woolworths.com.au/shop/search/products?searchTerm=toys$document ###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)
+
+---
+This filter template allows you to hide reseller ("market partner") items/ads and non-product titles from the Woolworths (AU) search results.

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -17,7 +17,7 @@ tags:
   - australia
 template: |
   {{#if market-partners}}
-  www.woolworths.com.au###search-content ##[class*="market-product-message-wrapper"]
+  www.woolworths.com.au###search-content shared-product-vendor-message:upward(div.product-grid-v2--tile)
   {{/if}}
   {{#if non-product-titles}}
   www.woolworths.com.au###search-content shared-inspiration-tile:upward(div.product-grid-v2--tile)

--- a/data/filters/templates/woolworths-cleanup.yaml
+++ b/data/filters/templates/woolworths-cleanup.yaml
@@ -9,7 +9,7 @@ params:
     type: checkbox
     default: true
   - name: non-product-titles
-    description: Hide non-product titles in search results
+    description: Hide non-product tiles in search results
     type: checkbox
     default: true
 tags:


### PR DESCRIPTION
Note: Currently a draft PR as I need to fix the tests.

Add a filter template to cleanup search results on the Woolworths (AU) site.

Can be used to:

- Remove reseller (aka "market partner") results [^1]
- Remove non-product results [^2]

Fixes: https://github.com/letsblockit/letsblockit/issues/496

[^1]: ![SCR-20230717-joxe-2](https://github.com/letsblockit/letsblockit/assets/862951/95c6283a-3325-4856-9e99-bb3fe7ee64b9)

[^2]: ![SCR-20230717-jpsx-2](https://github.com/letsblockit/letsblockit/assets/862951/fbc9c00c-5c0b-4f34-acf7-9fb301e6f18d)

