### PR TITLE
youtube-shorts: fix regression in search results

### DIFF
--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -20,6 +20,8 @@ template: |
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-item-section-renderer)
   {{! Trending section }}
   www.youtube.com##ytd-browse[page-subtype="trending"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
+  {{! Search results }}
+  www.youtube.com##ytd-search .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Wide-band rules to hide generic forms of short shelves across different pages }}
   www.youtube.com##ytd-rich-shelf-renderer[is-shorts]
   www.youtube.com##ytd-reel-shelf-renderer


### PR DESCRIPTION
Add back search-results since I could reproduce it.
![afbeelding](https://github.com/letsblockit/letsblockit/assets/80090789/0e0d3fb0-596b-497d-a56c-7b60752bc7d1)

***
Quick question: should we hide the COVID-19 banner, or is that too political to do?