### PR TITLE
youtube-shorts: avoid gaps in video grids by hiding the shelf's container

### DIFF
--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -24,6 +24,7 @@ template: |
   www.youtube.com##ytd-search .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Wide-band rules to hide generic forms of short shelves across different pages }}
   www.youtube.com##ytd-rich-shelf-renderer[is-shorts]
+  www.youtube.com##ytd-rich-shelf-renderer[is-shorts].ytd-rich-section-renderer:upward(ytd-rich-section-renderer)
   www.youtube.com##ytd-reel-shelf-renderer
   {{! Mobile homepage shorts shelf }}
   m.youtube.com##ytm-reel-shelf-renderer


### PR DESCRIPTION
In the homepage and subscription pages, the video grid can be interrupted with a partial row. This is where the shorts shelf sits, and it's `ytd-rich-section-renderer` container breaks the reflow.

I'm adding a separate rule for this case, to keep the `www.youtube.com##ytd-rich-shelf-renderer[is-shorts]` rule as wide as possible for future-proofing.