### PR TITLE
youtube-shorts: hide individual shorts in recommendation sidebar

### DIFF
--- a/data/filters/templates/youtube-shorts.yaml
+++ b/data/filters/templates/youtube-shorts.yaml
@@ -18,6 +18,8 @@ template: |
   www.youtube.com##ytd-search .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Subscriptions in list mode, hide the whole section as subsequent videos from same channel are currently pushed in separate sections }}
   www.youtube.com##ytd-browse[page-subtype="subscriptions"] ytd-video-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-item-section-renderer)
+  {{! Suggestion sidebar, individual shorts }}
+  www.youtube.com##ytd-watch-next-secondary-results-renderer .ytd-thumbnail[href^="/shorts/"]:upward(ytd-compact-video-renderer,ytd-shelf-renderer)
   {{! Trending section }}
   www.youtube.com##ytd-browse[page-subtype="trending"] .ytd-thumbnail[href^="/shorts/"]:upward(ytd-video-renderer)
   {{! Search results }}


### PR DESCRIPTION
Re-introduce the rule removed in https://github.com/letsblockit/letsblockit/commit/b6c092c178d144e57b768218f46cc8dd203661fa, as this layout is back.