### PR TITLE
youtube-cleanup: update rule for channel clarification

### DIFF
--- a/data/filters/templates/youtube-cleanup.yaml
+++ b/data/filters/templates/youtube-cleanup.yaml
@@ -64,6 +64,7 @@ tags:
 template: |
   {{#if channel-clarification}}
   www.youtube.com###clarify-box
+  www.youtube.com###above-the-fold #middle-row ytd-info-panel-content-renderer
   www.youtube.com##ytd-shorts .disclaimer-container:upward(#info-panel)
   m.youtube.com##shorts-video ytm-info-panel-container-renderer
   {{/if}}
@@ -129,6 +130,7 @@ tests:
       channel-clarification: true
     output: |
       www.youtube.com###clarify-box
+      www.youtube.com###above-the-fold #middle-row ytd-info-panel-content-renderer
       www.youtube.com##ytd-shorts .disclaimer-container:upward(#info-panel)
       m.youtube.com##shorts-video ytm-info-panel-container-renderer
   - params:


### PR DESCRIPTION
YT has a new layout at my side, which causes the blue clarification box visible again. See `https://www.youtube.com/watch?v=Wp0BJNpEzB4`.  This rule solves it. 
Notice: the other rules still exist in YT source code.