### PR TITLE
google-search-cleanup: Hides "People also search for" on mobile versions

### DIFF
--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -57,6 +57,7 @@ template: |
   {{#if also-search}}
   {{! These unfurl after clicking on a result and going back to the results page }}
   www.google.*###rso div.g div[jscontroller][id^="eob_"]
+  www.google.*###rso div.MjjYud:has(div[jsname="Cpkphb"] a[href^="/search?"])
   {{/if}}
   {{#if similar-image-searches}}
   www.google.*##div.isv-r[data-rfg]
@@ -94,6 +95,7 @@ tests:
     output: |
       www.google.*###botstuff #bres
       www.google.*###rso div.g div[jscontroller][id^="eob_"]
+      www.google.*###rso div.MjjYud:has(div[jsname="Cpkphb"] a[href^="/search?"])
       www.google.*###footcnt > #fbarcnt
   - params:
       similar-image-searches: true


### PR DESCRIPTION
Link used for testing: `https://www.google.com/search?q=remove+people+also+search+for#ip=1`

The rules for `People also ask` also works on mobile versions, but `People also search for` not.  The proposed rule did not give false positives both on the mobile version as on the normal version of google.