### PR TITLE
github-cleanup: remove outdated option to hide "For you" feed

### DIFF
--- a/data/filters/templates/github-cleanup.yaml
+++ b/data/filters/templates/github-cleanup.yaml
@@ -5,10 +5,6 @@ contributors:
   - Nomes77
   - xvello
 params:
-  - name: homepage-foryou
-    description: Hide the new "For you" feed on the homepage
-    type: checkbox
-    default: true
   - name: homepage-changelog
     description: Hide the changelog and announcements from the homepage
     type: checkbox
@@ -32,10 +28,6 @@ params:
 tags:
   - github
 template: |
-  {{#if homepage-foryou}}
-  github.com###dashboard .js-feeds-tabs #feed-next
-  github.com###dashboard tab-container div[aria-labelledby="feed-next"]
-  {{/if}}
   {{#if homepage-changelog}}
   github.com##aside .dashboard-changelog.mb-4
   github.com##.js-notice
@@ -60,11 +52,6 @@ tests:
     output: |
       github.com##aside .dashboard-changelog.mb-4
       github.com##.js-notice
-  - params:
-      homepage-foryou: true
-    output: |
-      github.com###dashboard .js-feeds-tabs #feed-next
-      github.com###dashboard tab-container div[aria-labelledby="feed-next"]
   - params:
       homepage-explore: true
     output: |


### PR DESCRIPTION
The "For you" feed is non-optional now, so this rule is outdated. Let's remove it to avoid confusion. Also, the feed can be configured now, so it's less obnoxiously bad:
![image](https://github.com/letsblockit/letsblockit/assets/6241083/88689b28-6ed4-4add-8709-b4ad09711260)


This is safe for existing users: the option will stay in the DB but be unused without error, and deleted the next time the user updates that template's configuration.