### PR TITLE
youtube-music-cleanup: fix broken `/moods_and_genres` page

### DIFF
--- a/data/filters/templates/youtube-music-cleanup.yaml
+++ b/data/filters/templates/youtube-music-cleanup.yaml
@@ -40,10 +40,10 @@ template: |
   music.youtube.com##h2 a[href="mixed_for_you"]:upward(ytmusic-carousel-shelf-renderer)
   {{/if}}
   {{#if remove-recommended-playlists}}
-  music.youtube.com##h2 a[href="moods_and_genres"]:upward(ytmusic-carousel-shelf-renderer)
+  music.youtube.com##h2 a[href="moods_and_genres"]:upward(ytmusic-carousel-shelf-renderer):not(:matches-path(/moods_and_genres))
   {{/if}}
   {{#if remove-youtube-made-playlists}}
-  music.youtube.com##yt-formatted-string > .yt-formatted-string:has-text(YouTube Music):upward(.ytmusic-carousel)
+  music.youtube.com##yt-formatted-string > .yt-formatted-string:has-text(YouTube Music):upward(.ytmusic-carousel):not(:matches-path(/moods_and_genres))
   music.youtube.com##ytmusic-grid-renderer[grid-type="library"] yt-formatted-string:has-text(YouTube Music):upward(ytmusic-two-row-item-renderer)
   music.youtube.com###contentContainer ytmusic-guide-entry-renderer[play-button-state] .subtitle-group:has-text(YouTube Music):upward(ytmusic-guide-entry-renderer)
   {{/if}}
@@ -71,11 +71,11 @@ tests:
   - params:
       remove-recommended-playlists: true
     output: |
-      music.youtube.com##h2 a[href="moods_and_genres"]:upward(ytmusic-carousel-shelf-renderer)
+      music.youtube.com##h2 a[href="moods_and_genres"]:upward(ytmusic-carousel-shelf-renderer):not(:matches-path(/moods_and_genres))
   - params:
       remove-youtube-made-playlists: true
     output: |
-      music.youtube.com##yt-formatted-string > .yt-formatted-string:has-text(YouTube Music):upward(.ytmusic-carousel)
+      music.youtube.com##yt-formatted-string > .yt-formatted-string:has-text(YouTube Music):upward(.ytmusic-carousel):not(:matches-path(/moods_and_genres))
       music.youtube.com##ytmusic-grid-renderer[grid-type="library"] yt-formatted-string:has-text(YouTube Music):upward(ytmusic-two-row-item-renderer)
       music.youtube.com###contentContainer ytmusic-guide-entry-renderer[play-button-state] .subtitle-group:has-text(YouTube Music):upward(ytmusic-guide-entry-renderer)
   - params:


### PR DESCRIPTION
If you go to `https://music.youtube.com/moods_and_genres` and click on one off the genres or moods, the page is broken. This PR fixes that problem