### PR TITLE
google-search-cleanup: Hide rich context result section in search box

### DIFF
--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -35,6 +35,10 @@ params:
     description: Hide "Reviews" in right hand pane
     type: checkbox
     default: false
+  - name: search-pane
+    description: Hide instant answer and rich context result section in the search box
+    type: checkbox
+    default: false
 tags:
   - google
 template: |
@@ -71,6 +75,9 @@ template: |
   {{#if review-pane}}
   www.google.*###rhs #kp-wp-tab-overview div[data-attrid$="review_summary"]
   www.google.*###rhs #kp-wp-tab-overview div[data-attrid$="third_party_aggregator_ratings"]
+  {{/if}}
+  {{#if search-pane}}
+  www.google.*###searchform ul[role="listbox"] > li.sbre:upward(div[jsname][role="presentation"])
   {{/if}}
 tests:
   - params: {}
@@ -110,6 +117,10 @@ tests:
     output: |
       www.google.*###rhs #kp-wp-tab-overview div[data-attrid$="review_summary"]
       www.google.*###rhs #kp-wp-tab-overview div[data-attrid$="third_party_aggregator_ratings"]
+  - params:
+      search-pane: true
+    output: |
+      www.google.*###searchform ul[role="listbox"] > li.sbre:upward(div[jsname][role="presentation"])
   - params: {}
 ---
 


### PR DESCRIPTION
Fixes #611