### PR TITLE
soundcloud-reposts: fix typo

### DIFF
--- a/data/filters/templates/soundcloud-reposts.yaml
+++ b/data/filters/templates/soundcloud-reposts.yaml
@@ -1,4 +1,4 @@
-title: "Soundcloud: hide reposts"
+title: "SoundCloud: hide reposts"
 contributors:
   - xvello
 tags:
@@ -74,7 +74,7 @@ tests:
   - output: ""
 ---
 
-Soundcloud allows artists to post original music, but also to share ("repost") other user's tracks. If you are only
+SoundCloud allows artists to post original music, but also to share ("repost") other user's tracks. If you are only
 interested in original music by the artists you follow, this filter template is for you.
 
 It will hide reposts in the stream page and the user page. By default, reposts from all users are hidden, but you


### PR DESCRIPTION
It's "SoundCloud", not "Soundcloud".