### PR TITLE
youtube-video-duration: fix examples

### DIFF
--- a/data/filters/templates/youtube-video-duration.yaml
+++ b/data/filters/templates/youtube-video-duration.yaml
@@ -51,7 +51,7 @@ The input should be a regexp. In regexp '`\d`' is for every possible digit. Mult
 - between 10 and 25 minutes: `1\d:\d\d|2[0-5]:\d\d`
 - less than one hour: `\d\d:\d\d`
 - one hour or more: `[1-9]:\d\d:\d\d|\d\d:\d\d:\d\d` or shorter `([1-9]|\d\d):\d\d:\d\d`
-- less than 10 hours: `\d:\d\d:\d\d`
+- between 1 and 9 hours: `\d:\d\d:\d\d`
 - 10 hours or more: `\d\d:\d\d:\d\d`
 - 15 hours or more: `(1[5-9]|[2-9]\d):\d\d:\d\d`
 

--- a/data/filters/templates/youtube-video-duration.yaml
+++ b/data/filters/templates/youtube-video-duration.yaml
@@ -50,8 +50,10 @@ The input should be a regexp. In regexp '`\d`' is for every possible digit. Mult
 - 10 minutes or more: `[1-9]\d:\d\d|\d:\d\d:\d\d|\d\d:\d\d:\d\d` or shorter `[1-9]\d:\d\d|(\d|\d\d):\d\d:\d\d`
 - between 10 and 25 minutes: `1\d:\d\d|2[0-5]:\d\d`
 - less than one hour: `\d\d:\d\d`
-- one hour or more: `1:\d\d:\d\d|\d\d:\d\d:\d\d` or shorter `(1|\d\d):\d\d:\d\d`
-- 2 hours or more: `2:\d\d:\d\d|\d\d:\d\d:\d\d` or shorter `(2|\d\d):\d\d:\d\d`
+- one hour or more: `[1-9]:\d\d:\d\d|\d\d:\d\d:\d\d` or shorter `([1-9]|\d\d):\d\d:\d\d`
+- less than 10 hours: `\d:\d\d:\d\d`
+- 10 hours or more: `\d\d:\d\d:\d\d`
+- 15 hours or more: `(1[5-9]|[2-9]\d):\d\d:\d\d`
 
 So if you want a regexp with less than a minute and between one and two minutes, the rule becomes: `0:\d\d|1:\d\d` or shorter `[0-1]:\d\d`
 


### PR DESCRIPTION
Fix https://github.com/letsblockit/letsblockit/issues/621#issuecomment-1901822084

```txt
I implemented two rules:

  *   Exclude videos shorter than 1 minute: 0:\d\d
  *   Exclude videos longer than one hour: 1:\d\d:\d\d|\d\d:\d\d:\d\d

I don't see any short vids on my home page, but this 1h36m video displayed on the home page: https://www.youtube.com/watch?v=701pwm78Q90
```