### PR TITLE
google-search-cleanup: fix comments

### DIFF
--- a/data/filters/templates/google-search-cleanup.yaml
+++ b/data/filters/templates/google-search-cleanup.yaml
@@ -9,13 +9,13 @@ params:
     type: checkbox
     default: true
     rules: |
-      ## Toplevel rich content above columns
+      !# Toplevel rich content above columns
       www.google.*###rcnt > div:first-of-type:not([id]) > div:has(g-more-link,g-scrolling-carousel,g-img)
-      ## Rich content in normal pages
+      !# Rich content in normal pages
       www.google.*###rso:has(> div:nth-of-type(6)) > div:has(g-more-link,g-section-with-header)
-      ## "Find results on" carousel
+      !# "Find results on" carousel
       www.google.*###rso:has(> div:nth-of-type(6)) > div:has(div[role="heading"]+g-scrolling-carousel)
-      ## New page layout for books / movies / shows, some rich elements are not handled yet
+      !# New page layout for books / movies / shows, some rich elements are not handled yet
       www.google.*###kp-wp-tab-overview > div:has(g-more-link,g-section-with-header,#media_result_group)
   - name: related-questions
     description: Hide the "People also ask" contextual content
@@ -34,7 +34,7 @@ params:
     type: checkbox
     default: true
     rules: |
-      ## These unfurl after clicking on a result and going back to the results page
+      !# These unfurl after clicking on a result and going back to the results page
       www.google.*###rso div.g div[jscontroller][id^="eob_"]
       www.google.*###rso div.MjjYud:has(div[jsname="Cpkphb"] a[href^="/search?"])
   - name: search-pane
@@ -49,7 +49,7 @@ params:
     type: checkbox
     default: false
     rules: |
-      ## Desktop browsers
+      !# Desktop browsers
       ||google.*/complete/search?q&cp=0$domain=google.*,important
       ## Mobile browsers
       ||google.*/complete/search?q&pq&cp=0$domain=google.*,important


### PR DESCRIPTION
Fixes https://github.com/letsblockit/letsblockit/issues/649, lines starting with `# ` are comments, but `## ` leads to a parsing error on some extensions. Let's use `!#`, as any line starting with `!` is parsed as a comment.