### PR TITLE
upgrade-deps.sh: stop upgrading frontend deps

### DIFF
--- a/scripts/upgrade-deps.sh
+++ b/scripts/upgrade-deps.sh
@@ -13,11 +13,11 @@ go get -t -u ./...
 go mod tidy
 ./scripts/update-vendorsha.sh
 
-# Upgrade npm deps
-cd src/assets
-npm upgrade -S
-npm prune
-cd ../..
+# Upgrade npm deps - skipped for project shutdown
+# cd src/assets
+# npm upgrade -S
+# npm prune
+# cd ../..
 
 # Rebuild assets, accounting for file renames
 git rm -rf data/assets/dist/


### PR DESCRIPTION
Let's keep upgrading backend deps, but freeze frontend deps. We'll upgrade manually if a CVE were to be published (unlikely given the limited scope of these deps).